### PR TITLE
Graceful shutdown for session reconnection

### DIFF
--- a/restart.sh
+++ b/restart.sh
@@ -18,5 +18,5 @@ cp server.js ~/.deepsteve/
 cp -r public/* ~/.deepsteve/public/
 
 launchctl unload ~/Library/LaunchAgents/com.deepsteve.plist 2>/dev/null
-sleep 1
+sleep 3
 launchctl load ~/Library/LaunchAgents/com.deepsteve.plist


### PR DESCRIPTION
## Summary
- Sends Ctrl+C to Claude shells before killing, giving them time to save conversation state
- Phased shutdown: Ctrl+C → wait 5s → SIGTERM → wait 2s → SIGKILL
- Bumps restart.sh sleep from 1s to 3s to allow graceful shutdown to complete

Closes #10

## Test plan
- [ ] Restart daemon with `./restart.sh` while sessions are active
- [ ] Verify sessions can be resumed after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)