### PR TITLE
Fix terminal sizing to fill full window

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -172,8 +172,10 @@ body { background: #0d1117; color: #c9d1d9; font-family: system-ui; height: 100v
 .issue-empty { padding: 16px; text-align: center; color: #8b949e; font-size: 13px; }
 
 /* Terminal containers */
-.terminal-container { flex: 1; display: none; position: relative; }
-.terminal-container.active { display: block; }
+#terminals { flex: 1; min-height: 0; position: relative; }
+.terminal-container { position: absolute; inset: 0; display: none; }
+.terminal-container.active { display: flex; flex-direction: column; }
+.terminal-container .xterm { flex: 1; }
 .terminal-container.reconnecting::after {
   content: 'Reconnecting...';
   position: absolute;

--- a/public/js/terminal.js
+++ b/public/js/terminal.js
@@ -43,3 +43,33 @@ export function fitTerminal(term, fit, ws) {
     rows: term.rows
   }));
 }
+
+/**
+ * Measure the cols/rows that would fit in the #terminals container
+ * using a temporary hidden terminal. Returns {cols, rows} or defaults.
+ */
+export function measureTerminalSize() {
+  const container = document.getElementById('terminals');
+  if (!container || container.clientWidth === 0 || container.clientHeight === 0) {
+    return { cols: 120, rows: 40 };
+  }
+
+  // Create a temporary off-screen terminal to measure cell size
+  const tmp = document.createElement('div');
+  tmp.style.cssText = 'position:absolute;visibility:hidden;pointer-events:none;';
+  container.appendChild(tmp);
+
+  const term = new Terminal({ fontSize: 14 });
+  const fit = new FitAddon.FitAddon();
+  term.loadAddon(fit);
+  term.open(tmp);
+
+  const dims = fit.proposeDimensions();
+  term.dispose();
+  tmp.remove();
+
+  if (dims && dims.cols > 0 && dims.rows > 0) {
+    return { cols: dims.cols, rows: dims.rows };
+  }
+  return { cols: 120, rows: 40 };
+}

--- a/public/js/ws-client.js
+++ b/public/js/ws-client.js
@@ -9,6 +9,8 @@ export function createWebSocket(options = {}) {
   if (options.cwd) params.set('cwd', options.cwd);
   if (options.isNew) params.set('new', '1');
   if (options.worktree) params.set('worktree', options.worktree);
+  if (options.cols) params.set('cols', options.cols);
+  if (options.rows) params.set('rows', options.rows);
 
   const url = 'ws://' + location.host + '?' + params;
   let ws = new WebSocket(url);


### PR DESCRIPTION
## Summary
- Terminals now fill the full `#terminals` container using absolute + flex layout
- Measures actual terminal dimensions before WebSocket connect and passes cols/rows to server
- PTY spawns at correct size instead of hardcoded 120x40
- Double-rAF ensures layout is complete before fitting

Closes #12

## Test plan
- [ ] Open deepsteve — terminal should fill the available height
- [ ] New tabs should have correct column width matching the window
- [ ] Resize browser window — terminal should refit

🤖 Generated with [Claude Code](https://claude.com/claude-code)