### PR TITLE
Fix magic wand sessions not getting named

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -228,7 +228,7 @@ function createSession(cwd, existingId = null, isNew = false, opts = {}) {
         // Check if this WebSocket already has a session (reconnect case)
         const existingSession = [...sessions.entries()].find(([, s]) => s.ws === ws);
         if (!existingSession) {
-          initTerminal(msg.id, ws, cwd);
+          initTerminal(msg.id, ws, cwd, opts.name);
           if (opts.initialPrompt) {
             ws.sendJSON({ type: 'initialPrompt', text: opts.initialPrompt });
           }
@@ -288,7 +288,7 @@ function createSession(cwd, existingId = null, isNew = false, opts = {}) {
 /**
  * Initialize a terminal after WebSocket connection is established
  */
-function initTerminal(id, ws, cwd) {
+function initTerminal(id, ws, cwd, initialName) {
   const container = document.createElement('div');
   container.className = 'terminal-container';
   container.id = 'term-' + id;
@@ -301,7 +301,7 @@ function initTerminal(id, ws, cwd) {
   const windowId = getWindowId();
   const savedSessions = SessionStore.getWindowSessions(windowId);
   const savedSession = savedSessions.find(s => s.id === id);
-  const name = savedSession?.name || getDefaultTabName(cwd);
+  const name = savedSession?.name || initialName || getDefaultTabName(cwd);
 
   // Store session in memory
   sessions.set(id, { term, fit, ws, container, cwd, name, waitingForInput: false });
@@ -625,7 +625,8 @@ Please read the issue carefully, understand the codebase context, and implement 
 
     createSession(gitRoot, null, true, {
       worktree: 'github-issue-' + selectedIssue.number,
-      initialPrompt: prompt
+      initialPrompt: prompt,
+      name: `#${selectedIssue.number} ${selectedIssue.title}`
     });
   }
 


### PR DESCRIPTION
## Summary
- Pass issue name (e.g. `#15 Bug title`) from `showIssuePicker()` through `createSession()` to `initTerminal()` so tabs created via the magic wand get a descriptive name instead of the generic directory name

Closes #15

## Test plan
- [ ] Click the magic wand button, pick a GitHub issue, and verify the new tab is named with the issue number and title (e.g. `#15 New terminal sessions from magic wand aren't getting named`)
- [ ] Verify existing sessions (created via `+ New` button or directory picker) still get the default directory-based name
- [ ] Verify renamed tabs persist their custom name on page refresh (savedSession?.name takes priority)

🤖 Generated with [Claude Code](https://claude.com/claude-code)