### PR TITLE
Auto-clear browser notifications on terminal interaction

### DIFF
--- a/public/js/terminal.js
+++ b/public/js/terminal.js
@@ -19,10 +19,13 @@ export function createTerminal(container) {
   return { term, fit };
 }
 
-export function setupTerminalIO(term, ws) {
+export function setupTerminalIO(term, ws, { onUserInput } = {}) {
   // Note: ws.onmessage is set in app.js to handle JSON control messages
   // and route terminal data here via term.write()
-  term.onData((data) => ws.send(data));
+  term.onData((data) => {
+    ws.send(data);
+    if (onUserInput) onUserInput();
+  });
 
   // Handle Shift+Enter for multi-line input
   term.attachCustomKeyEventHandler((event) => {


### PR DESCRIPTION
## Summary
- Track active `Notification` objects and close them programmatically when the user returns to the terminal
- Clear notifications on: browser tab focus, session tab switch, and terminal keystroke
- Closes #5

## Test plan
- [ ] Trigger a notification by having Claude wait for input while the tab is in the background
- [ ] Switch back to the browser tab — notification should auto-dismiss
- [ ] Switch between session tabs — notification for the newly active tab should clear
- [ ] Type in the terminal — any notification for that session should clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)