### PR TITLE
Tower mod: show terminal name tooltip on hover

### DIFF
--- a/mods/tower/tower.jsx
+++ b/mods/tower/tower.jsx
@@ -95,6 +95,7 @@ function Computer({ x, y, screenColor, sessionName, waiting, onClick }) {
 
   return (
     <g onClick={onClick} style={{ cursor: onClick ? "pointer" : "default" }}>
+      {sessionName && <title>{sessionName}</title>}
       {/* Monitor */}
       <rect x={x} y={y} width={monW} height={monH} rx={p} fill={PALETTE.computer.body} />
       <rect x={x + p} y={y + p} width={monW - 2 * p} height={monH - 4 * p} fill={PALETTE.computer.screen} />


### PR DESCRIPTION
## Summary
- Add SVG `<title>` element to the `Computer` component in the Tower mod so hovering over a terminal block shows the full session name as a native browser tooltip
- Especially useful when session names are truncated (>10 chars) in the pixel text label

## Test plan
- [ ] Open the Tower mod with multiple sessions assigned to floors
- [ ] Hover over a computer block — verify the full session name appears as a tooltip
- [ ] Verify long names (>10 chars) show the full untruncated name in the tooltip
- [ ] Verify computers without a session name don't show an empty tooltip

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)