### PR TITLE
Limit display length of GitHub issue titles in tabs

### DIFF
--- a/server.js
+++ b/server.js
@@ -28,7 +28,7 @@ app.use((req, res, next) => {
 });
 
 // Load settings
-let settings = { shellProfile: '~/.zshrc' };
+let settings = { shellProfile: '~/.zshrc', maxIssueTitleLength: 25 };
 try {
   if (fs.existsSync(SETTINGS_FILE)) {
     settings = { ...settings, ...JSON.parse(fs.readFileSync(SETTINGS_FILE, 'utf8')) };
@@ -356,12 +356,16 @@ app.get('/api/settings', (req, res) => {
 });
 
 app.post('/api/settings', (req, res) => {
-  const { shellProfile } = req.body;
+  const { shellProfile, maxIssueTitleLength } = req.body;
   if (shellProfile !== undefined) {
     settings.shellProfile = shellProfile;
-    saveSettings();
     log(`Settings updated: shellProfile=${shellProfile}`);
   }
+  if (maxIssueTitleLength !== undefined) {
+    settings.maxIssueTitleLength = Math.max(10, Math.min(200, Number(maxIssueTitleLength) || 25));
+    log(`Settings updated: maxIssueTitleLength=${settings.maxIssueTitleLength}`);
+  }
+  saveSettings();
   res.json(settings);
 });
 


### PR DESCRIPTION
## Summary
- Default max display length for issue titles in tabs changed from 50 to 25 characters (plus ellipsis)
- Full title still stored internally and sent to Claude in the initial prompt
- Adds configurable "Issue Title Length" setting in the Settings modal (range: 10–200)
- Setting persisted to `~/.deepsteve/settings.json` via existing settings API

## Test plan
- [ ] Restart daemon, open Settings modal, verify "Issue Title Length" field shows 25
- [ ] Create a session from a GitHub issue with a long title, confirm tab truncates at 25 chars + ellipsis
- [ ] Change setting to a different value, save, create another issue session, confirm new limit applies
- [ ] Reload page, reopen Settings, confirm value persisted
- [ ] Check `~/.deepsteve/settings.json` contains `maxIssueTitleLength`

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)