### PR TITLE
Add empty state dark background for legibility

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -341,3 +341,13 @@ body { background: var(--ds-bg-primary); color: var(--ds-text-primary); font-fam
 .mod-setting-toggle { flex-shrink: 0; margin-top: 2px; accent-color: var(--ds-accent-green); cursor: pointer; width: 16px; height: 16px; }
 .mod-setting-label { font-size: 13px; color: var(--ds-text-primary); cursor: pointer; }
 .mod-setting-desc { font-size: 12px; color: var(--ds-text-secondary); margin-top: 2px; }
+
+/* Empty state (no tabs open) */
+#empty-state { position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 0; user-select: none; background: #0d0d0d; animation: empty-state-fade-in 0.4s ease-out; }
+#empty-state.hidden { display: none; }
+#empty-state pre { margin: 0; font-family: monospace; line-height: 1.1; }
+#empty-state .empty-state-icon { color: var(--ds-accent-blue); opacity: 0.7; font-size: 14px; }
+#empty-state .empty-state-title { color: var(--ds-accent-blue); opacity: 0.4; font-size: 12px; margin-top: 8px; }
+#empty-state .empty-state-hint { color: var(--ds-text-secondary); font-size: 13px; margin-top: 20px; opacity: 0.6; }
+#empty-state .empty-state-hint kbd { background: var(--ds-bg-tertiary); border: 1px solid var(--ds-border); border-radius: 3px; padding: 2px 6px; font-family: inherit; font-size: 12px; }
+@keyframes empty-state-fade-in { from { opacity: 0; } to { opacity: 1; } }

--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,39 @@
       <button id="settings-btn" class="dropdown-btn">⚙</button>
     </div>
     <div id="sidebar-resizer"></div>
-    <div id="terminals"></div>
+    <div id="terminals">
+      <div id="empty-state">
+        <pre class="empty-state-icon">
+               ▄▄▄▄▄▄▄▄▄▄▄
+           ▄█▀▀██████████▀█▄
+         ▄█▀▄█████████████▄██
+   ▄▄▄▄▄███████████████████████▄▄
+   ████▄███████████████████████▄▀█▄
+   ▀███████████████████▀   ████████
+    ████████████████▀▀     ▀███████▄
+   ██████▀██████▀▀▀          ▀▀█████
+   ▀████   ▄▄▄▄▄▄       ▄▄▄▄▄   ████▄▄
+    ███   █▀    ▀█▄▄▄▄▄█▀   ▀█▄  ████▀
+     ██▀▀██      ██▀▀▀█       █▀▀██
+      █   █▄    ▄█▀   ▀█     █▀  ██
+      █    ▀▀███▀      ▀▀███▀▀   ██
+      █                         ▄█▀
+      █                        ▄█▀
+      █                      ▄██▀
+      █                 ▄▄▄▄█▀▀
+      █    ▄█▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+      █ ▄██▀
+      ██▀</pre>
+        <pre class="empty-state-title">
+     _                     _
+  __| | ___  ___ _ __  ___| |_ _____   _____
+ / _` |/ _ \/ _ \ '_ \/ __| __/ _ \ \ / / _ \
+| (_| |  __/  __/ |_) \__ \ ||  __/\ V /  __/
+ \__,_|\___|\___| .__/|___/\__\___| \_/ \___|
+                |_|</pre>
+        <p class="empty-state-hint">Click <kbd>+ New</kbd> to get started</p>
+      </div>
+    </div>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.js"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -158,6 +158,11 @@ function updateTitle() {
   document.title = count > 0 ? `(${count}) deepsteve` : 'deepsteve';
 }
 
+function updateEmptyState() {
+  const el = document.getElementById('empty-state');
+  if (el) el.classList.toggle('hidden', sessions.size > 0);
+}
+
 /**
  * Build a session list for the mod bridge API
  */
@@ -537,6 +542,7 @@ function initTerminal(id, ws, cwd, initialName, { hasScrollback = false, pending
   };
 
   TabManager.addTab(id, name, tabCallbacks);
+  updateEmptyState();
   switchTo(id);
 
   // Save to both storages — TabSessions is per-tab truth, SessionStore is for cross-tab
@@ -633,6 +639,8 @@ function killSession(id) {
       activeId = null;
     }
   }
+
+  updateEmptyState();
 
   // Notify mods of session list change
   ModManager.notifySessionsChanged(getSessionList());


### PR DESCRIPTION
## Summary
- Ports the empty state placeholder (ASCII icon + figlet title + hint) into the repo source
- Adds solid `#0d0d0d` background so the empty state is legible on all themes (e.g. retro-monitor)

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)