### PR TITLE
Broadcast theme changes via live-reload WebSocket

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -904,7 +904,11 @@ async function init() {
   });
 
   // Auto-reload browser when server restarts (restart.sh, node --watch, etc.)
-  initLiveReload();
+  initLiveReload({
+    onMessage: (msg) => {
+      if (msg.type === 'theme') applyTheme(msg.css || '');
+    }
+  });
 
   // Load settings before creating any terminals (prevents color flash, applies title length)
   try {

--- a/public/js/live-reload.js
+++ b/public/js/live-reload.js
@@ -6,7 +6,7 @@
  * On normal restart, the WS drops and we silently reconnect without refreshing.
  */
 
-export function initLiveReload() {
+export function initLiveReload({ onMessage } = {}) {
   let ws;
   let shouldReload = false;
   let intentionallyClosed = false;
@@ -19,6 +19,8 @@ export function initLiveReload() {
         const msg = JSON.parse(e.data);
         if (msg.type === 'reload') {
           shouldReload = true;
+        } else if (onMessage) {
+          onMessage(msg);
         }
       } catch {}
     };

--- a/server.js
+++ b/server.js
@@ -95,6 +95,12 @@ function broadcastTheme(name, css) {
       client.send(msg);
     }
   }
+  // Also send to live-reload clients so tabs with no sessions still get theme updates
+  for (const client of reloadClients) {
+    if (client.readyState === 1) {
+      client.send(msg);
+    }
+  }
 }
 
 // Spawn claude with full login shell environment (like iTerm does)


### PR DESCRIPTION
## Summary
- Theme broadcasts now also go to live-reload WebSocket clients, not just session WebSockets
- Tabs with no sessions (empty state) now receive theme updates
- `initLiveReload()` accepts an `onMessage` callback for non-reload messages

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)