### PR TITLE
Persist custom tab names through close and restore

### DIFF
--- a/public/js/ws-client.js
+++ b/public/js/ws-client.js
@@ -11,6 +11,7 @@ export function createWebSocket(options = {}) {
   if (options.worktree) params.set('worktree', options.worktree);
   if (options.cols) params.set('cols', options.cols);
   if (options.rows) params.set('rows', options.rows);
+  if (options.name) params.set('name', options.name);
 
   let url = 'ws://' + location.host + '?' + params;
   let ws = new WebSocket(url);

--- a/server.js
+++ b/server.js
@@ -231,7 +231,7 @@ function saveState() {
   }
   const state = {};
   for (const [id, entry] of shells) {
-    state[id] = { cwd: entry.cwd, claudeSessionId: entry.claudeSessionId, worktree: entry.worktree || null, lastActivity: entry.lastActivity || null };
+    state[id] = { cwd: entry.cwd, claudeSessionId: entry.claudeSessionId, worktree: entry.worktree || null, name: entry.name || null, lastActivity: entry.lastActivity || null };
   }
   // Merge with any saved state that wasn't reconnected yet
   const merged = { ...savedState, ...state };
@@ -415,8 +415,8 @@ app.get('/api/mods', (req, res) => {
 });
 
 app.get('/api/shells', (req, res) => {
-  const active = [...shells.entries()].map(([id, entry]) => ({ id, pid: entry.shell.pid, cwd: entry.cwd, status: 'active', lastActivity: entry.lastActivity || null }));
-  const saved = Object.entries(savedState).map(([id, entry]) => ({ id, cwd: entry.cwd, status: 'saved', lastActivity: entry.lastActivity || null }));
+  const active = [...shells.entries()].map(([id, entry]) => ({ id, pid: entry.shell.pid, cwd: entry.cwd, name: entry.name || null, status: 'active', lastActivity: entry.lastActivity || null }));
+  const saved = Object.entries(savedState).map(([id, entry]) => ({ id, cwd: entry.cwd, name: entry.name || null, status: 'saved', lastActivity: entry.lastActivity || null }));
   res.json({ shells: [...active, ...saved] });
 });
 
@@ -528,6 +528,7 @@ wss.on('connection', (ws, req) => {
   if (cwd.startsWith('~')) cwd = path.join(os.homedir(), cwd.slice(1));
   const createNew = url.searchParams.get('new') === '1';
   const worktree = url.searchParams.get('worktree');
+  const name = url.searchParams.get('name');
   const initialCols = parseInt(url.searchParams.get('cols')) || 120;
   const initialRows = parseInt(url.searchParams.get('rows')) || 40;
 
@@ -551,7 +552,8 @@ wss.on('connection', (ws, req) => {
       if (savedWorktree) resumeArgs.push('--worktree', savedWorktree);
       const shell = spawnClaude(resumeArgs, cwd, ptySize);
       const startTime = Date.now();
-      shells.set(id, { shell, clients: new Set(), cwd, claudeSessionId, worktree: savedWorktree, restored: true, waitingForInput: false, lastActivity: Date.now() });
+      const restoredName = name || restored.name || null;
+      shells.set(id, { shell, clients: new Set(), cwd, claudeSessionId, worktree: savedWorktree, name: restoredName, restored: true, waitingForInput: false, lastActivity: Date.now() });
       wireShellOutput(id);
       shell.onExit(() => {
         if (shuttingDown) return;  // Don't overwrite state file during shutdown
@@ -596,7 +598,7 @@ wss.on('connection', (ws, req) => {
     if (worktree) claudeArgs.push('--worktree', worktree);
     log(`[WS] Creating NEW shell: oldId=${oldId}, newId=${id}, claudeSession=${claudeSessionId}, worktree=${worktree || 'none'}, cwd=${cwd}`);
     const shell = spawnClaude(claudeArgs, cwd, { cols: initialCols, rows: initialRows });
-    shells.set(id, { shell, clients: new Set(), cwd, claudeSessionId, worktree: worktree || null, waitingForInput: false, lastActivity: Date.now() });
+    shells.set(id, { shell, clients: new Set(), cwd, claudeSessionId, worktree: worktree || null, name: name || null, waitingForInput: false, lastActivity: Date.now() });
     wireShellOutput(id);
     shell.onExit(() => { if (!shuttingDown) { shells.delete(id); saveState(); } });
     saveState();
@@ -611,7 +613,7 @@ wss.on('connection', (ws, req) => {
   entry.clients.add(ws);
   const hasScrollback = entry.scrollback && entry.scrollback.length > 0;
   log(`[WS] Sending session response: id=${id}, restored=${entry.restored || false}, scrollback=${hasScrollback ? entry.scrollbackSize + 'B' : 'none'}`);
-  ws.send(JSON.stringify({ type: 'session', id, restored: entry.restored || false, cwd: entry.cwd, scrollback: hasScrollback }));
+  ws.send(JSON.stringify({ type: 'session', id, restored: entry.restored || false, cwd: entry.cwd, name: entry.name || null, scrollback: hasScrollback }));
 
   // Send buffered scrollback so the client can render the terminal immediately
   if (hasScrollback) {
@@ -627,6 +629,7 @@ wss.on('connection', (ws, req) => {
       if (parsed.type === 'resize') { entry.shell.resize(parsed.cols, parsed.rows); return; }
       if (parsed.type === 'redraw') { entry.shell.write('\x0c'); return; } // Ctrl+L
       if (parsed.type === 'initialPrompt') { entry.initialPrompt = parsed.text; return; }
+      if (parsed.type === 'rename') { entry.name = parsed.name || null; return; }
     } catch {}
     // User sent input - update activity and clear waiting state
     entry.lastActivity = Date.now();
@@ -645,7 +648,7 @@ wss.on('connection', (ws, req) => {
       entry.killTimer = setTimeout(() => {
         if (entry.clients.size === 0) {
           // Preserve session info so it can be restored on next connect
-          savedState[id] = { cwd: entry.cwd, claudeSessionId: entry.claudeSessionId, worktree: entry.worktree || null, lastActivity: entry.lastActivity || null };
+          savedState[id] = { cwd: entry.cwd, claudeSessionId: entry.claudeSessionId, worktree: entry.worktree || null, name: entry.name || null, lastActivity: entry.lastActivity || null };
           killShell(entry, id);
           shells.delete(id);
           saveState();


### PR DESCRIPTION
## Summary
- Store session `name` server-side (shell entries, `state.json`, `/api/shells` responses)
- Send `rename` WS message to server when user renames a tab
- Pass name through the Sessions dropdown restore flow so it's available on reconnect
- Also sync renames to `TabSessions` (sessionStorage) which was previously missed

Fixes #34

## Test plan
- [ ] Rename a tab to a custom name
- [ ] Close the tab
- [ ] Open Sessions dropdown — verify the custom name is shown (not the repo name)
- [ ] Click the session to restore — verify the tab opens with the custom name
- [ ] Restart the daemon — verify saved sessions retain their custom names

🤖 Generated with [Claude Code](https://claude.com/claude-code)