### PR TITLE
Add panel toggle tabs on right edge (#43)

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -301,8 +301,14 @@ body { background: var(--ds-bg-primary); color: var(--ds-text-primary); font-fam
 #mod-container iframe { width: 100%; height: 100%; border: none; }
 
 /* Panel container (side panel for panel-mode mods) */
-#panel-container { display: none; flex-shrink: 0; width: 360px; overflow: hidden; border-left: 1px solid var(--ds-border); }
-#panel-container iframe { width: 100%; height: 100%; border: none; }
+#panel-container { display: none; flex-shrink: 0; width: 360px; overflow: hidden; border-left: 1px solid var(--ds-border); position: relative; }
+#panel-container iframe { position: absolute; inset: 0; width: 100%; height: 100%; border: none; }
+
+/* Panel tabs (right edge vertical tab strip) */
+#panel-tabs { display: none; flex-direction: column; flex-shrink: 0; background: var(--ds-bg-secondary); border-left: 1px solid var(--ds-border); }
+.panel-tab { writing-mode: vertical-rl; padding: 12px 6px; background: transparent; border: none; border-left: 2px solid transparent; color: var(--ds-text-secondary); font-size: 12px; cursor: pointer; white-space: nowrap; }
+.panel-tab:hover { color: var(--ds-text-primary); background: var(--ds-bg-tertiary); }
+.panel-tab.active { color: var(--ds-accent-blue); border-left-color: var(--ds-accent-blue); background: var(--ds-bg-tertiary); }
 
 /* Panel resizer */
 #panel-resizer { display: none; width: 4px; background: var(--ds-border); cursor: col-resize; flex-shrink: 0; transition: background 0.15s; }


### PR DESCRIPTION
## Summary
- Panel mods now all stay loaded simultaneously (iframes kept alive) so MCP tools work regardless of which panel is visible
- Vertical tab strip on the right edge lets users switch between enabled panel mods (Tasks, Console)
- Clicking the active tab collapses the panel; clicking another tab switches to it
- Bridge API callbacks tagged with modId for proper cleanup on mod reload/disable

## Test plan
- [ ] Enable both Tasks and Console mods — verify right-side vertical tabs appear
- [ ] Click tabs to switch panels, click active tab to collapse
- [ ] Disable a mod — tab disappears, panel switches to remaining mod
- [ ] Verify MCP tools (add_task, browser_eval) work with both mods enabled
- [ ] Verify panel resizer still works
- [ ] Verify fullscreen mods (Tower) still work

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)