### PR TITLE
Magic Wand: plan mode, custom prompt template, visual pop

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -185,10 +185,10 @@ body { background: var(--ds-bg-primary); color: var(--ds-text-primary); font-fam
 #new-btn:hover { background: var(--ds-accent-green-hover); }
 #new-btn:active { background: var(--ds-accent-green-active); }
 
-/* Wand button */
-#wand-btn { padding: 4px 10px; background: var(--ds-btn-neutral); border: none; color: var(--ds-text-primary); border-radius: 4px; cursor: pointer; font-size: 13px; margin-left: 4px; user-select: none; }
-#wand-btn:hover { background: var(--ds-btn-neutral-hover); }
-#wand-btn:active { background: var(--ds-btn-neutral-active); }
+/* Wand button — lighter than neutral buttons to stand out */
+#wand-btn { padding: 4px 10px; background: #474e57; border: none; color: var(--ds-text-primary); border-radius: 4px; cursor: pointer; font-size: 13px; margin-left: 4px; user-select: none; }
+#wand-btn:hover { background: #545d68; }
+#wand-btn:active { background: #3d444d; }
 
 /* Vertical layout wand button */
 #app-container.vertical-layout #wand-btn { width: 100%; margin: 4px 0 0 0; }

--- a/server.js
+++ b/server.js
@@ -27,8 +27,21 @@ app.use((req, res, next) => {
   express.json()(req, res, next);
 });
 
+// Settings defaults (single source of truth for wand template + plan mode)
+const SETTINGS_DEFAULTS = {
+  wandPlanMode: true,
+  wandPromptTemplate: `I need you to work on GitHub issue #{{number}}: "{{title}}"
+Labels: {{labels}}
+URL: {{url}}
+
+Issue description:
+{{body}}
+
+Please read the issue carefully, understand the codebase context, and implement the changes needed.`
+};
+
 // Load settings
-let settings = { shellProfile: '~/.zshrc', maxIssueTitleLength: 25 };
+let settings = { shellProfile: '~/.zshrc', maxIssueTitleLength: 25, ...SETTINGS_DEFAULTS };
 try {
   if (fs.existsSync(SETTINGS_FILE)) {
     settings = { ...settings, ...JSON.parse(fs.readFileSync(SETTINGS_FILE, 'utf8')) };
@@ -154,11 +167,29 @@ function wireShellOutput(id) {
       e.waitingForInput = true;
       const stateMsg = JSON.stringify({ type: 'state', waiting: true });
       e.clients.forEach((c) => c.send(stateMsg));
-      if (e.initialPrompt) {
-        const prompt = e.initialPrompt;
-        e.initialPrompt = null;
+
+      // Step 2 of plan mode: /plan was sent, now send the actual prompt
+      if (e.pendingPlanPrompt) {
+        const prompt = e.pendingPlanPrompt;
+        e.pendingPlanPrompt = null;
         e.waitingForInput = false;
         setTimeout(() => submitToShell(e.shell, prompt), 500);
+        return;
+      }
+
+      if (e.initialPrompt) {
+        const prompt = e.initialPrompt;
+        const planMode = e.planMode || false;
+        e.initialPrompt = null;
+        e.planMode = false;
+        e.waitingForInput = false;
+        if (planMode) {
+          // Step 1: send /plan first, then the prompt on the next BEL
+          e.pendingPlanPrompt = prompt;
+          setTimeout(() => submitToShell(e.shell, '/plan'), 500);
+        } else {
+          setTimeout(() => submitToShell(e.shell, prompt), 500);
+        }
       }
     }
   });
@@ -364,6 +395,8 @@ app.get('/api/settings', (req, res) => {
   res.json({ ...settings, themeCSS });
 });
 
+app.get('/api/settings/defaults', (req, res) => res.json(SETTINGS_DEFAULTS));
+
 app.post('/api/settings', (req, res) => {
   const { shellProfile, maxIssueTitleLength } = req.body;
   if (shellProfile !== undefined) {
@@ -373,6 +406,14 @@ app.post('/api/settings', (req, res) => {
   if (maxIssueTitleLength !== undefined) {
     settings.maxIssueTitleLength = Math.max(10, Math.min(200, Number(maxIssueTitleLength) || 25));
     log(`Settings updated: maxIssueTitleLength=${settings.maxIssueTitleLength}`);
+  }
+  if (req.body.wandPlanMode !== undefined) {
+    settings.wandPlanMode = !!req.body.wandPlanMode;
+    log(`Settings updated: wandPlanMode=${settings.wandPlanMode}`);
+  }
+  if (req.body.wandPromptTemplate !== undefined) {
+    settings.wandPromptTemplate = String(req.body.wandPromptTemplate);
+    log(`Settings updated: wandPromptTemplate (${settings.wandPromptTemplate.length} chars)`);
   }
   saveSettings();
   res.json(settings);
@@ -637,7 +678,7 @@ wss.on('connection', (ws, req) => {
       const parsed = JSON.parse(str);
       if (parsed.type === 'resize') { entry.shell.resize(parsed.cols, parsed.rows); return; }
       if (parsed.type === 'redraw') { entry.shell.write('\x0c'); return; } // Ctrl+L
-      if (parsed.type === 'initialPrompt') { entry.initialPrompt = parsed.text; return; }
+      if (parsed.type === 'initialPrompt') { entry.initialPrompt = parsed.text; entry.planMode = parsed.planMode || false; return; }
       if (parsed.type === 'rename') { entry.name = parsed.name || null; return; }
     } catch {}
     // User sent input - update activity and clear waiting state


### PR DESCRIPTION
## Summary
- Start GitHub issues in plan mode by default (sends `/plan` first, then the prompt on the next BEL). Configurable via Settings.
- Make the prompt template customizable with `{{number}}`, `{{title}}`, `{{labels}}`, `{{url}}`, `{{body}}` template variables. Reset button fetches server defaults.
- Make wand button visually lighter to stand out from neutral buttons.

## Test plan
- [ ] Wand button is visually lighter/more prominent
- [ ] Settings → "Magic Wand" section shows plan mode checkbox and prompt template textarea
- [ ] Pick issue via wand → Claude receives `/plan` first, then the rendered prompt
- [ ] Uncheck plan mode → Claude gets prompt directly
- [ ] Edit prompt template → custom template used with variables substituted
- [ ] Reset button resets template to default
- [ ] Settings persist across server restart

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)