### PR TITLE
Add checklist support to tasks mod

### DIFF
--- a/mods/tasks/tools.js
+++ b/mods/tasks/tools.js
@@ -155,6 +155,20 @@ function registerRoutes(app, context) {
     res.json({ task });
   });
 
+  app.post('/api/tasks/:id/description', (req, res) => {
+    const id = parseInt(req.params.id);
+    const { description } = req.body;
+    const task = tasks.find(t => t.id === id);
+    if (!task) return res.status(404).json({ error: 'Task not found' });
+    if (typeof description !== 'string') {
+      return res.status(400).json({ error: 'Invalid description' });
+    }
+    task.description = description;
+    saveTasks();
+    broadcastTasks();
+    res.json({ task });
+  });
+
   app.delete('/api/tasks/:id', (req, res) => {
     const id = parseInt(req.params.id);
     const idx = tasks.findIndex(t => t.id === id);


### PR DESCRIPTION
## Summary
- Render markdown-style checklists (`- [ ]` / `- [x]`) in task descriptions as interactive checkboxes
- Add `POST /api/tasks/:id/description` endpoint for persisting checklist toggle state
- Non-checklist descriptions render unchanged

## Test plan
- [x] Verified checkboxes render and toggle correctly in the tasks panel

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)