### PR TITLE
Add mod versioning with compatibility checking

### DIFF
--- a/mods/browser-console/mod.json
+++ b/mods/browser-console/mod.json
@@ -1,5 +1,7 @@
 {
   "name": "Console",
+  "version": "0.1.0",
+  "minDeepsteveVersion": "0.1.0",
   "description": "Browser console passthrough for Claude sessions",
   "entry": "index.html",
   "display": "panel",

--- a/mods/tasks/mod.json
+++ b/mods/tasks/mod.json
@@ -1,5 +1,7 @@
 {
   "name": "Tasks",
+  "version": "0.1.0",
+  "minDeepsteveVersion": "0.1.0",
   "description": "Task list for human actions, populated by Claude sessions",
   "entry": "index.html",
   "display": "panel",

--- a/mods/tower/mod.json
+++ b/mods/tower/mod.json
@@ -1,5 +1,7 @@
 {
   "name": "Tower",
+  "version": "0.1.0",
+  "minDeepsteveVersion": "0.1.0",
   "description": "Pixel art skyscraper view of your Claude sessions",
   "entry": "index.html",
   "toolbar": {

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -367,6 +367,12 @@ body { background: var(--ds-bg-primary); color: var(--ds-text-primary); font-fam
 .mod-settings-btn { background: transparent; border: none; color: var(--ds-text-secondary); cursor: pointer; font-size: 14px; padding: 2px 6px; border-radius: 3px; line-height: 1; flex-shrink: 0; }
 .mod-settings-btn:hover { background: var(--ds-bg-tertiary); color: var(--ds-text-primary); }
 
+/* Mod versioning */
+.mod-incompatible { opacity: 0.5; }
+.mod-incompatible input[type="checkbox"] { pointer-events: none; }
+.mod-version { color: var(--ds-text-secondary); }
+.mod-warning { font-size: 11px; color: var(--ds-accent-red); margin-top: 2px; }
+
 /* Mod settings modal */
 .mod-setting-item { display: flex; align-items: flex-start; gap: 10px; padding: 12px 0; border-bottom: 1px solid var(--ds-border); }
 .mod-setting-item:last-child { border-bottom: none; }


### PR DESCRIPTION
## Summary
- Add `version` (required) and `minDeepsteveVersion` (optional) fields to all mod.json manifests
- Server computes `compatible` flag per mod and includes `deepsteveVersion` in `/api/mods` response
- Frontend shows version next to each mod, dims incompatible mods with warning, and blocks enabling them
- Bridge API exposes `getDeepsteveVersion()` for mod iframes

Closes #71

## Test plan
- [ ] Open Mods dropdown — each mod shows `v0.1.0` next to its description
- [ ] Set a mod's `minDeepsteveVersion` to `"99.0.0"` — appears dimmed with warning, checkbox disabled
- [ ] Revert test change — mod loads normally again
- [ ] In mod iframe console: `window.deepsteve.getDeepsteveVersion()` returns `"0.1.0"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)