### PR TITLE
Add drag-and-drop file support for terminals

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -389,3 +389,29 @@ body { background: var(--ds-bg-primary); color: var(--ds-text-primary); font-fam
 #empty-state .empty-state-hint { color: var(--ds-text-secondary); font-size: 13px; margin-top: 20px; opacity: 0.6; }
 #empty-state .empty-state-hint kbd { background: var(--ds-bg-tertiary); border: 1px solid var(--ds-border); border-radius: 3px; padding: 2px 6px; font-family: inherit; font-size: 12px; }
 @keyframes empty-state-fade-in { from { opacity: 0; } to { opacity: 1; } }
+
+/* File drop zone overlay */
+.file-drop-zone {
+  position: absolute;
+  inset: 0;
+  z-index: 50;
+  border: 2px dashed var(--ds-accent-green);
+  background: rgba(35, 134, 54, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  pointer-events: none;
+}
+.file-drop-zone.visible { opacity: 1; }
+.file-drop-zone-content {
+  background: var(--ds-bg-secondary);
+  color: var(--ds-text-bright);
+  padding: 16px 32px;
+  border-radius: 8px;
+  font-size: 15px;
+  font-weight: 600;
+  border: 1px solid var(--ds-accent-green);
+}
+

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -12,6 +12,7 @@ import { showWindowRestoreModal } from './window-restore-modal.js';
 import { LayoutManager } from './layout-manager.js';
 import { initLiveReload } from './live-reload.js';
 import { ModManager } from './mod-manager.js';
+import { initFileDrop } from './file-drop.js';
 
 // Configuration
 let maxIssueTitleLength = 25;
@@ -960,6 +961,16 @@ async function init() {
     focusSession: switchTo,
     createSession: (cwd) => createSession(cwd, null, true),
     killSession: killSession,
+  });
+
+  // File drag-and-drop upload
+  initFileDrop({
+    getActiveSession: () => {
+      if (!activeId) return null;
+      const s = sessions.get(activeId);
+      if (!s) return null;
+      return { id: activeId, cwd: s.cwd, container: s.container, ws: s.ws };
+    }
   });
 
   // Auto-reload browser when server restarts (restart.sh, node --watch, etc.)

--- a/public/js/file-drop.js
+++ b/public/js/file-drop.js
@@ -1,0 +1,112 @@
+/**
+ * Drag-and-drop file support for terminal sessions.
+ *
+ * Drops a file into /tmp/deepsteve-drops/ via the server, then types the full
+ * path into the terminal — like dropping a file into iTerm.
+ */
+
+let getActiveSession = null;
+let dragDepth = 0;
+let dropZone = null;
+
+function hasFiles(e) {
+  return e.dataTransfer && e.dataTransfer.types.includes('Files');
+}
+
+function showDropZone() {
+  const session = getActiveSession();
+  if (!session) return;
+
+  if (!dropZone) {
+    dropZone = document.createElement('div');
+    dropZone.className = 'file-drop-zone';
+    dropZone.innerHTML = '<div class="file-drop-zone-content">Drop files here</div>';
+  }
+
+  session.container.appendChild(dropZone);
+  dropZone.offsetHeight; // force reflow for transition
+  dropZone.classList.add('visible');
+}
+
+function hideDropZone() {
+  if (dropZone) dropZone.classList.remove('visible');
+}
+
+/** Shell-escape a path (wrap in single quotes, escape internal quotes). */
+function shellEscape(s) {
+  if (/^[a-zA-Z0-9/._\-]+$/.test(s)) return s;
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+/**
+ * Upload a file to /tmp/deepsteve-drops/. Returns the full path on success,
+ * null on failure.
+ */
+function uploadFile(file) {
+  return new Promise((resolve) => {
+    const xhr = new XMLHttpRequest();
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try {
+          resolve(JSON.parse(xhr.responseText).path);
+        } catch {
+          resolve(null);
+        }
+      } else {
+        resolve(null);
+      }
+    };
+    xhr.onerror = () => resolve(null);
+    xhr.open('PUT', `/api/upload/${encodeURIComponent(file.name)}`);
+    xhr.send(file);
+  });
+}
+
+export function initFileDrop({ getActiveSession: getter }) {
+  getActiveSession = getter;
+  const terminals = document.getElementById('terminals');
+
+  terminals.addEventListener('dragenter', (e) => {
+    if (!hasFiles(e)) return;
+    e.preventDefault();
+    dragDepth++;
+    if (dragDepth === 1) showDropZone();
+  });
+
+  terminals.addEventListener('dragover', (e) => {
+    if (!hasFiles(e)) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+  });
+
+  terminals.addEventListener('dragleave', (e) => {
+    if (!hasFiles(e)) return;
+    dragDepth--;
+    if (dragDepth === 0) hideDropZone();
+  });
+
+  terminals.addEventListener('drop', async (e) => {
+    if (!hasFiles(e)) return;
+    e.preventDefault();
+    dragDepth = 0;
+    hideDropZone();
+
+    const session = getActiveSession();
+    if (!session) return;
+
+    const files = [...e.dataTransfer.files];
+    if (files.length === 0) return;
+
+    // Upload all files, collect paths
+    const paths = [];
+    for (const file of files) {
+      const p = await uploadFile(file);
+      if (p) paths.push(p);
+    }
+
+    // Type the paths into the terminal, space-separated
+    if (paths.length > 0) {
+      session.ws.send(paths.map(shellEscape).join(' '));
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Drop files onto a terminal to upload to `/tmp/deepsteve-drops/` and type the full path into the terminal input (like iTerm file drops)
- Duplicate filenames auto-deduplicate (`screenshot.png`, `screenshot-1.png`, etc.)
- Green dashed drop zone overlay on dragenter for visual feedback

Closes #1

## Test plan
- [ ] Drop a file onto a terminal — verify path gets typed
- [ ] Drop the same file twice — verify deduplication suffix
- [ ] Drop multiple files — verify space-separated paths
- [ ] Drag text selection (not a file) — verify drop zone does NOT activate

🤖 Generated with [Claude Code](https://claude.com/claude-code)