### PR TITLE
Fix: prevent browser navigation on file drop

### DIFF
--- a/public/js/file-drop.js
+++ b/public/js/file-drop.js
@@ -66,6 +66,10 @@ export function initFileDrop({ getActiveSession: getter }) {
   getActiveSession = getter;
   const terminals = document.getElementById('terminals');
 
+  // Prevent browser from navigating to dropped files anywhere on the page
+  document.addEventListener('dragover', (e) => { if (hasFiles(e)) e.preventDefault(); });
+  document.addEventListener('drop', (e) => { if (hasFiles(e)) e.preventDefault(); });
+
   terminals.addEventListener('dragenter', (e) => {
     if (!hasFiles(e)) return;
     e.preventDefault();


### PR DESCRIPTION
## Summary
- Adds document-level `dragover`/`drop` preventDefault to stop the browser from navigating to dropped files (showing "leave page?" dialog)

## Test plan
- [ ] Drop a file on the terminal — works as before
- [ ] Drop a file on the tab bar or other non-terminal area — no navigation prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)