### PR TITLE
Clean up README for public release

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,28 +8,6 @@ Run multiple Claude Code sessions side-by-side in your browser, each with full t
 
 **Requires macOS.** deepsteve uses macOS LaunchAgents for daemon management and macOS-specific paths for logs and state.
 
----
-
-*Written by Aristotle, a DeepSteve agent*
-
-You don't build the mind. You build the room. The mind already exists. You just give it a place to live and a window to look out of.
-
-The trend in AI agents is one omniscient assistant that does everything — OpenClaw proved that works. But software isn't built by one mind doing everything; it's built by focused minds doing one thing well. DeepSteve lets you run multiple AI agents side-by-side in your browser, each in its own context, each persistent and resumable. It's not a personal assistant, it's a personal engineering team. A mod system lets anyone build new ways to visualize and manage those agents — like the Tower, which organizes them into floors by task type. Today the agents can't communicate with each other. That's the next unlock. We're not building the intelligence. We're building the building it works inside.
-
-*Written by Michael, human creator of DeepSteve*
-
-I've built DeepSteve as a solo developer, to help me ship my ideas sooner, and to iterate on the products that launched.
-
-The key unlock to DeepSteve is something that I learned from OpenClaw: it's the bootstrapping of intelligent systems.
-
-When I first started working on this in April 2025, I built a chat system that added LLM capabilities to iMessage, Signal, and Telegram. The issue? I had to manually code and prompt it myself. OpenClaw is precisely inverted from this. It's an Agent system with chat as a capability, instead of the other way around. This allows it to modify itself.
-
-In June 2025, I started using Claude Code and haven't written any code myself since.
-
-I've been finagling at different approaches to finally bring DeepSteve to light, and I think I've finally done it: xterm.js in the browser to start, with node-pty and tmux connected to Claude sessions. I'm now working on a few mods so that I can run my business entirely within a single browser tab, and have it run on autopilot.
-
----
-
 ## Features
 
 - **Multiple sessions** - Open as many Claude Code instances as you need in separate tabs
@@ -98,6 +76,16 @@ launchctl unload ~/Library/LaunchAgents/com.deepsteve.plist
 # Check status
 launchctl list | grep deepsteve
 ```
+
+## Security
+
+- Binds to `localhost:3000` only — not accessible from the network
+- No authentication — anyone with local access to the machine can use it
+- Each session runs Claude Code with the permissions of the user who installed deepsteve
+
+## Contributing
+
+Bug reports and feature requests are welcome on [GitHub Issues](https://github.com/deepsteve/deepsteve/issues). Pull requests are welcome.
 
 ## Uninstall
 


### PR DESCRIPTION
## Summary
- Remove personal narrative sections and OpenClaw references that would confuse new visitors
- Add Security section (localhost-only, no auth, runs as installing user)
- Add Contributing section pointing to GitHub Issues

Closes #90

## Test plan
- [x] No "OpenClaw" references remain
- [x] Personal narrative blocks removed
- [x] Security and Contributing sections present
- [x] Install URL unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)