### PR TITLE
Document localhost-only security posture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,10 @@ Key input handling:
 - Shift+Enter: intercepted, sends `\x1b[13;2u` (CSI u encoding)
 - Resize: FitAddon calculates cols/rows, sends JSON message to server
 
+### Security
+
+DeepSteve has **no authentication, no CORS, and no WebSocket origin checking**. It is designed for localhost use only. The server binds to all interfaces (`0.0.0.0`) — do not expose port 3000 to untrusted networks. All API endpoints, the MCP endpoint, and WebSocket connections are unauthenticated.
+
 ### Gotchas and Non-Obvious Behavior
 
 - **Ink input parsing**: `shell.write("text\r")` doesn't work for submitting to Claude. Text and `\r` must be sent separately with a 1s delay (`submitToShell()`), because Ink only recognizes Enter when `\r` arrives as its own stdin read.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Run multiple Claude Code sessions side-by-side in your browser, each with full t
 
 **Requires macOS.** deepsteve uses macOS LaunchAgents for daemon management and macOS-specific paths for logs and state.
 
+> **Security notice:** DeepSteve has no authentication, no CORS restrictions, and no WebSocket origin checking. It is designed for **localhost use only**. Do not expose it to a network or the public internet.
+
 ## Features
 
 - **Multiple sessions** - Open as many Claude Code instances as you need in separate tabs

--- a/release.sh
+++ b/release.sh
@@ -146,6 +146,9 @@ launchctl load "$PLIST_PATH"
 
 echo "deepsteve installed and running at http://localhost:3000"
 echo "To uninstall: ~/.deepsteve/uninstall.sh"
+echo ""
+echo "⚠️  Security: DeepSteve has no authentication. It is localhost-only."
+echo "   Do not expose port 3000 to a network or the public internet."
 POSTAMBLE
 
 chmod +x "$OUT"


### PR DESCRIPTION
## Summary
- Add security notice blockquote to README.md near the top
- Add security warning to install output in release.sh
- Add Security subsection under Architecture in CLAUDE.md

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)