### PR TITLE
Add --bind CLI flag for configurable listen address

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -116,6 +116,8 @@ embed_text "uninstall.sh" "uninstall.sh"
   echo '        <string>production</string>'
   echo '        <key>PORT</key>'
   echo '        <string>3000</string>'
+  echo '        <key>DEEPSTEVE_BIND</key>'
+  echo '        <string>127.0.0.1</string>'
   echo '        <key>PATH</key>'
   echo '        <string>$INSTALL_DIR/node/bin:$HOME/.local/bin:$(dirname $NODE_PATH):/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>'
   echo '    </dict>'


### PR DESCRIPTION
## Summary
- Adds `--bind <address>` CLI flag and `DEEPSTEVE_BIND` env var to configure the server listen address (CLI flag takes precedence)
- Validates the address with `net.isIP()` and exits with a clear error for invalid values
- Prints a prominent security warning when binding to non-localhost addresses
- Adds `DEEPSTEVE_BIND` to the LaunchAgent plist template in `release.sh`

Closes #96

## Test plan
- [x] Default: binds to `127.0.0.1:3000`
- [x] `--bind 0.0.0.0`: shows warning, binds to `0.0.0.0`
- [x] `DEEPSTEVE_BIND=0.0.0.0`: same via env var
- [x] CLI flag overrides env var
- [x] `--bind invalid`: exits with error

🤖 Generated with [Claude Code](https://claude.com/claude-code)