### PR TITLE
Add scroll-to-bottom button for terminal scrollback

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -433,6 +433,28 @@ body { background: var(--ds-bg-primary); color: var(--ds-text-primary); font-fam
   pointer-events: none;
 }
 .file-drop-zone.visible { opacity: 1; }
+/* Scroll-to-bottom floating button */
+.scroll-to-bottom {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 5;
+  padding: 4px 16px;
+  background: var(--ds-bg-secondary);
+  border: 1px solid var(--ds-border);
+  border-radius: 16px;
+  color: var(--ds-text-secondary);
+  font-size: 14px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  pointer-events: none;
+  box-shadow: 0 2px 8px var(--ds-shadow);
+}
+.scroll-to-bottom.visible { opacity: 1; pointer-events: auto; }
+.scroll-to-bottom:hover { background: var(--ds-bg-tertiary); color: var(--ds-text-primary); border-color: var(--ds-accent-blue); }
+
 .file-drop-zone-content {
   background: var(--ds-bg-secondary);
   color: var(--ds-text-bright);

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -560,7 +560,8 @@ function initTerminal(id, ws, cwd, initialName, { hasScrollback = false, pending
 
   const { term, fit } = createTerminal(container);
   const scrollControl = setupTerminalIO(term, ws, {
-    onUserInput: () => clearNotification(id)
+    onUserInput: () => clearNotification(id),
+    container
   });
 
   // Get saved name or generate default


### PR DESCRIPTION
## Summary
- Adds a floating pill-shaped ↓ button that appears when the user scrolls up in a terminal
- Clicking the button scrolls to bottom, hides it, and refocuses the terminal
- Each tab gets its own button via closure — tab switches auto-hide it

Closes #103

## Test plan
- [ ] Generate scrollback output, scroll up → button appears
- [ ] Click button → scrolls to bottom, button disappears
- [ ] Switch tabs → button not visible on new tab
- [ ] Reconnect overlay / file-drop zone still render above the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)