### PR TITLE
Fix scroll-to-bottom: extract shared scrollToBottom()

### DIFF
--- a/public/js/terminal.js
+++ b/public/js/terminal.js
@@ -78,10 +78,15 @@ export function setupTerminalIO(term, ws, { onUserInput, container } = {}) {
   scrollBtn.setAttribute('aria-label', 'Scroll to bottom');
   if (container) container.appendChild(scrollBtn);
 
-  scrollBtn.addEventListener('click', () => {
+  function scrollToBottom() {
     userScrolledUp = false;
     term.scrollToBottom();
+    term.refresh(0, term.rows - 1);
     scrollBtn.classList.remove('visible');
+  }
+
+  scrollBtn.addEventListener('click', () => {
+    scrollToBottom();
     term.focus();
   });
 
@@ -96,19 +101,11 @@ export function setupTerminalIO(term, ws, { onUserInput, container } = {}) {
 
   term.onWriteParsed(() => {
     if (!userScrolledUp) {
-      term.scrollToBottom();
-      scrollBtn.classList.remove('visible');
+      scrollToBottom();
     }
   });
 
-  return {
-    scrollToBottom() {
-      userScrolledUp = false;
-      term.scrollToBottom();
-      term.refresh(0, term.rows - 1);
-      scrollBtn.classList.remove('visible');
-    }
-  };
+  return { scrollToBottom };
 }
 
 export function fitTerminal(term, fit, ws) {


### PR DESCRIPTION
## Summary
- Button click handler was duplicating scroll logic and missing `term.refresh()`
- Extracted shared `scrollToBottom()` function used by both the click handler and the returned API

Follow-up to #104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)