### PR TITLE
Namespace mod localStorage and enforce CSP (#45)

### DIFF
--- a/mods/tower/tower.jsx
+++ b/mods/tower/tower.jsx
@@ -33,25 +33,25 @@ const PROJECT_COLORS = [
   { name: "purple", screen: "#b388ff", glow: "rgba(179,136,255,0.15)" },
 ];
 
-const FLOORS_STORAGE_KEY = "tower-mod-floors";
+const FLOORS_KEY = "floors";
+const CWD_MAP_KEY = "session-cwds";
 
 function loadFloors() {
   try {
-    const raw = localStorage.getItem(FLOORS_STORAGE_KEY);
+    const raw = localStorage.getItem(FLOORS_KEY);
     if (raw) return JSON.parse(raw);
   } catch {}
   return [];
 }
 
 function saveFloors(floors) {
-  localStorage.setItem(FLOORS_STORAGE_KEY, JSON.stringify(floors));
+  localStorage.setItem(FLOORS_KEY, JSON.stringify(floors));
 }
-
-const CWD_MAP_KEY = "tower-mod-session-cwds";
 
 function loadCwdMap() {
   try { return JSON.parse(localStorage.getItem(CWD_MAP_KEY)) || {}; } catch { return {}; }
 }
+
 function saveCwdMap(map) {
   localStorage.setItem(CWD_MAP_KEY, JSON.stringify(map));
 }


### PR DESCRIPTION
## Summary
- Server injects a storage-scoping `<script>` preamble into mod HTML (right after `<head>`) that overrides `localStorage`/`sessionStorage` with `mod:<modId>:`-prefixed wrappers — runs before any mod scripts, no timing gap
- CSP header on `/mods` route restricts external scripts to a hardcoded allowlist (react@18, react-dom@18, babel/standalone on jsdelivr; Google Fonts for styles/fonts). Any other external script is blocked by the browser
- Tower mod updated to use short key names (`floors`, `session-cwds`) since scoping is now transparent

Closes #45

## Test plan
- [ ] Enable Tower mod, create floors, assign sessions — verify keys in DevTools are `mod:tower:floors` and `mod:tower:session-cwds`
- [ ] Verify Tasks and Console mods still work
- [ ] Verify deepsteve own localStorage keys (`deepsteve-enabled-mods`, etc.) are unaffected
- [ ] Check CSP: add a `<script src="https://evil.com/bad.js">` to a mod HTML, confirm it is blocked in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)