### PR TITLE
Fix screenshots mod: redundant body parser and missing validation

### DIFF
--- a/server.js
+++ b/server.js
@@ -53,7 +53,6 @@ app.use(express.static('public'));
 app.use('/mods', express.static('mods'));
 app.use((req, res, next) => {
   if (req.path === '/mcp') return next(); // MCP SDK parses its own body
-  if (req.path === '/api/screenshots/result') return express.json({ limit: '50mb' })(req, res, next);
   express.json()(req, res, next);
 });
 


### PR DESCRIPTION
## Summary
- Remove redundant 50MB JSON body parser from `server.js` global middleware — the route-level middleware in `tools.js` already handles it
- Validate `dataUrl` format (must be `data:image/png;base64,…` string) and decoded buffer (must be non-empty) before writing to disk

Fixes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)