### PR TITLE
Add Themes and Mods documentation guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,11 @@ Open [http://localhost:3000](http://localhost:3000) in your browser.
 
 ## Themes
 
-Place `.css` files in `~/.deepsteve/themes/` to add custom themes. Select the active theme from the settings panel (gear icon).
+Customize the UI with CSS theme files. See the [Themes Guide](docs/themes.md) for details.
 
 ## Mods
 
-Mods are visual extensions that provide alternative views of your sessions. Each mod lives in `mods/<name>/` with a `mod.json` manifest and an HTML entry point.
-
-Built-in mods:
-- **Tower** - A pixel art skyscraper visualization of your Claude sessions
-
-Enable and disable mods from the Mods dropdown in the toolbar.
+Extend deepsteve with visual mods — alternative views, panels, and MCP tools for your sessions. See the [Mods Guide](docs/mods.md) for details.
 
 ## Managing the Daemon
 

--- a/docs/mods.md
+++ b/docs/mods.md
@@ -1,0 +1,309 @@
+# Mods Guide
+
+Mods are extensions that add visual views and MCP tools to deepsteve. They run in sandboxed iframes with access to session data through a bridge API.
+
+## Using Mods
+
+### Enable/Disable
+
+Open the **Mods** dropdown in the toolbar to see all available mods. Toggle the checkbox to enable or disable each mod. Panel mods are auto-enabled on first visit.
+
+### Per-Mod Settings
+
+Mods can define boolean settings. Click the gear icon next to a mod in the dropdown to configure it. Settings are saved immediately to localStorage.
+
+### Display Modes
+
+Mods have two display modes:
+
+- **Fullscreen** — activated via a toolbar button, replaces the terminal view. Clicking a session in the mod switches back to the terminal with a back button to return. Only one fullscreen mod iframe exists at a time; it's created on show and destroyed on hide.
+- **Panel** — docked to the right side of the terminal area, with tabs if multiple panel mods are enabled. A drag handle allows resizing. Panel iframes stay alive even when hidden, so MCP tools keep working.
+
+### Built-in Mods
+
+| Mod | Display | Description | MCP Tools |
+|---|---|---|---|
+| **Tower** | fullscreen | Pixel art skyscraper view of sessions | — |
+| **Tasks** | panel | Task list populated by Agent sessions | `add_task`, `update_task`, `complete_task`, `list_tasks` |
+| **Screenshots** | panel | Capture terminal screenshots as PNG | `screenshot_capture` |
+| **Console** | panel | Browser console passthrough for Agents | `browser_eval`, `browser_console` |
+
+## Creating a Mod
+
+### Directory Structure
+
+```
+mods/<name>/
+  mod.json       # Manifest (required)
+  index.html     # Entry point (required)
+  tools.js       # MCP tools (optional)
+```
+
+### mod.json Reference
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Display name |
+| `version` | string | yes | Semver version (e.g. `"0.2.0"`) |
+| `minDeepsteveVersion` | string | no | Minimum compatible deepsteve version. Incompatible mods are shown but disabled. |
+| `description` | string | no | Short description shown in the Mods dropdown |
+| `entry` | string | no | HTML entry point, defaults to `"index.html"` |
+| `display` | string | no | `"panel"` for docked panel, omit for fullscreen (default) |
+| `panel.position` | string | no | `"right"` (only value currently supported) |
+| `panel.defaultWidth` | number | no | Initial panel width in pixels |
+| `panel.minWidth` | number | no | Minimum panel width when resizing |
+| `toolbar.label` | string | no | Label for the toolbar button (fullscreen mods only) |
+| `settings` | array | no | Per-mod boolean settings (see below) |
+| `tools` | array | no | MCP tool declarations (see [MCP Tools](#mcp-tools-toolsjs)) |
+
+**Settings entries:**
+
+```json
+{
+  "key": "allowMultiFloor",
+  "type": "boolean",
+  "label": "Allow multi-floor sessions",
+  "description": "Allow one session to be assigned to multiple floors at once",
+  "default": false
+}
+```
+
+**Tool entries:**
+
+```json
+{ "name": "add_task", "description": "Add a task for the human" }
+```
+
+### Example: Fullscreen Mod (Tower)
+
+```json
+{
+  "name": "Tower",
+  "version": "0.2.0",
+  "minDeepsteveVersion": "0.2.0",
+  "description": "Pixel art skyscraper view of your Agent sessions",
+  "entry": "index.html",
+  "toolbar": {
+    "label": "Tower"
+  },
+  "settings": [
+    {
+      "key": "allowMultiFloor",
+      "type": "boolean",
+      "label": "Allow multi-floor sessions",
+      "description": "Allow one session to be assigned to multiple floors at once",
+      "default": false
+    }
+  ]
+}
+```
+
+### Example: Panel Mod (Tasks)
+
+```json
+{
+  "name": "Tasks",
+  "version": "0.2.0",
+  "minDeepsteveVersion": "0.2.0",
+  "description": "Task list for human actions, populated by Agent sessions",
+  "entry": "index.html",
+  "display": "panel",
+  "panel": { "position": "right", "defaultWidth": 360, "minWidth": 200 },
+  "toolbar": { "label": "Tasks" },
+  "tools": [
+    { "name": "add_task", "description": "Add a task for the human" },
+    { "name": "update_task", "description": "Update a task" },
+    { "name": "complete_task", "description": "Mark a task as done" },
+    { "name": "list_tasks", "description": "List current tasks" }
+  ],
+  "settings": [
+    { "key": "panelPosition", "type": "boolean", "label": "Panel on left", "description": "Show panel on left side instead of right", "default": false }
+  ]
+}
+```
+
+## Bridge API (`deepsteve.*`)
+
+Every mod iframe gets a `deepsteve` object injected on its `window` after load. This is the only interface between mods and the host application.
+
+### `getDeepsteveVersion()`
+Returns the deepsteve version string (e.g. `"0.2.0"`).
+
+### `getSessions()`
+Returns an array of session objects with the current state of all sessions.
+
+### `focusSession(id)`
+Switches from the mod view to the terminal view and focuses the given session. For fullscreen mods, this hides the mod and shows a back button.
+
+### `onSessionsChanged(cb)`
+Registers a callback that fires whenever sessions change. Fires immediately with current sessions. Returns an unsubscribe function.
+
+```js
+const unsub = deepsteve.onSessionsChanged(sessions => {
+  console.log('Sessions:', sessions);
+});
+// Later: unsub();
+```
+
+### `createSession(cwd)`
+Creates a new Claude Code session in the given working directory.
+
+### `killSession(id)`
+Kills the session with the given ID.
+
+### `getSettings()`
+Returns the mod's current settings object — stored values merged with defaults from `mod.json`.
+
+### `onSettingsChanged(cb)`
+Registers a callback that fires when the mod's settings change. Fires immediately with current settings. Returns an unsubscribe function.
+
+### `onTasksChanged(cb)`
+Registers a callback that fires when tasks change (via the Tasks mod's MCP tools or REST API). Fires immediately after fetching current tasks from `/api/tasks`. Returns an unsubscribe function.
+
+### `onBrowserEvalRequest(cb)`
+Registers a callback that fires when a `browser_eval` MCP tool call is received. The callback receives `{ requestId, code }`. Used by the Console mod to execute JS in the browser and POST results back. Returns an unsubscribe function.
+
+### `onBrowserConsoleRequest(cb)`
+Registers a callback for `browser_console` MCP tool calls. Receives `{ requestId, level, limit, search }`. Returns an unsubscribe function.
+
+### `onScreenshotCaptureRequest(cb)`
+Registers a callback for `screenshot_capture` MCP tool calls. Receives `{ requestId, selector }`. Returns an unsubscribe function.
+
+## MCP Tools (`tools.js`)
+
+Mods can expose tools to Claude Code sessions via the MCP protocol. Tools are defined in a `tools.js` file using CommonJS exports.
+
+### `exports.init(context)`
+
+Called once at server startup. Returns an object mapping tool names to definitions:
+
+```js
+function init(context) {
+  const { broadcast } = context;
+
+  return {
+    my_tool: {
+      description: 'What this tool does',
+      schema: {
+        param1: z.string().describe('Description of param1'),
+        param2: z.number().optional().describe('Optional param'),
+      },
+      handler: async ({ param1, param2 }) => {
+        // Do work...
+        return {
+          content: [{ type: 'text', text: 'Result message' }],
+        };
+      },
+    },
+  };
+}
+```
+
+Each tool has:
+- **`description`** — shown to Claude in the MCP tool listing
+- **`schema`** — Zod shape object defining input parameters
+- **`handler`** — async function that receives validated params and returns an MCP content response
+
+### `exports.registerRoutes(app, context)` (optional)
+
+Register Express routes for browser-side communication (REST endpoints for the mod's iframe to call):
+
+```js
+function registerRoutes(app, context) {
+  app.get('/api/my-mod/data', (req, res) => {
+    res.json({ items: [] });
+  });
+}
+```
+
+### Context Object
+
+Both `init` and `registerRoutes` receive a context object:
+
+| Field | Description |
+|---|---|
+| `broadcast` | `broadcast(msg)` — send a WebSocket message to all connected clients |
+| `log` | `log(...args)` — write to the deepsteve log file |
+| `app` | Express app instance |
+| `shells` | Map of active shell instances |
+| `wss` | WebSocket server instance |
+| `MODS_DIR` | Absolute path to the `mods/` directory |
+
+### Browser-Bridge Pattern
+
+Some tools need to execute code in the browser (e.g. evaluating JS, capturing screenshots). Since the server can't access the DOM directly, these tools use a broadcast-and-respond pattern:
+
+1. MCP tool handler creates a `requestId` and a pending Promise
+2. Handler broadcasts a request message to all WebSocket clients
+3. The mod's iframe (registered via `onBrowserEvalRequest` etc.) receives the broadcast and executes the work
+4. The iframe POSTs the result back to a REST endpoint (e.g. `/api/browser-console/result`)
+5. The REST handler resolves the pending Promise, returning the result to Claude
+
+```js
+// In tools.js — handler broadcasts request, waits for browser response
+handler: async ({ code }) => {
+  const requestId = randomUUID();
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      pendingRequests.delete(requestId);
+      resolve({ content: [{ type: 'text', text: 'Error: Timed out.' }] });
+    }, TIMEOUT_MS);
+
+    pendingRequests.set(requestId, { resolve, timer });
+    broadcast({ type: 'browser-eval-request', requestId, code });
+  });
+},
+
+// In tools.js — registerRoutes receives browser response
+function registerRoutes(app, context) {
+  app.post('/api/browser-console/result', (req, res) => {
+    const { requestId, result, error } = req.body;
+    const pending = pendingRequests.get(requestId);
+    if (!pending) return res.json({ accepted: false });
+
+    pendingRequests.delete(requestId);
+    clearTimeout(pending.timer);
+    pending.resolve({
+      content: [{ type: 'text', text: error ? `Error: ${error}` : result }],
+    });
+    res.json({ accepted: true });
+  });
+}
+```
+
+## Mod Lifecycle
+
+### Iframe Sandboxing
+
+All mod iframes use `sandbox="allow-scripts allow-same-origin"`. This allows JavaScript execution and same-origin access (needed for the bridge API injection) while blocking other capabilities like popups and form submission.
+
+### Panel Mods
+
+Panel mod iframes are created when the mod is enabled and stay alive for the duration of the session. When you switch between panel tabs, iframes are shown/hidden via `display: none` — they are not destroyed. This is important because MCP tools registered by panel mods (e.g. `browser_eval`) need the iframe to be alive to handle requests.
+
+### Fullscreen Mods
+
+Fullscreen mod iframes are created when shown and destroyed when hidden. If you switch to a different fullscreen mod, the previous one's iframe is destroyed first. Session and settings callbacks registered by a fullscreen mod are cleaned up on hide.
+
+### Hot Reload
+
+The server watches mod directories with `fs.watch()`. When files change, it broadcasts a `mod-changed` message. Active iframes reload with a cache-busting query parameter. Stale bridge API callbacks are cleaned up before the iframe reloads.
+
+### Version Compatibility
+
+If a mod declares `minDeepsteveVersion`, the server compares it against its own version using semver. Incompatible mods appear in the Mods dropdown but are disabled (checkbox grayed out) with a "Requires deepsteve vX.Y.Z+" warning.
+
+## State & Storage
+
+Mod state is stored in localStorage with the following keys:
+
+| Key | Description |
+|---|---|
+| `deepsteve-enabled-mods` | JSON set of enabled mod IDs |
+| `deepsteve-active-mod-view` | ID of the currently shown fullscreen mod |
+| `deepsteve-panel-visible` | Whether the panel is visible (`"true"` / `"false"`) |
+| `deepsteve-active-panel` | ID of the active panel tab |
+| `deepsteve-panel-width` | Panel width in pixels (persisted across resizes) |
+| `deepsteve-mod-settings-<modId>` | Per-mod settings object (one key per mod) |
+
+Panel mods are auto-enabled on first visit (when no mod preferences have been saved yet).

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,0 +1,129 @@
+# Themes Guide
+
+Themes let you customize deepsteve's appearance by overriding CSS custom properties.
+
+## Using Themes
+
+1. Place `.css` files in `~/.deepsteve/themes/`
+2. Open the settings panel (gear icon in the toolbar)
+3. Select your theme from the dropdown
+
+Theme files are limited to 64KB. Changes are picked up via `fs.watch()` — edits to the active theme apply immediately without a page refresh.
+
+## Creating a Theme
+
+A theme file overrides any of the 25 CSS custom properties defined in `:root`. You don't need to override all of them — only the ones you want to change.
+
+### Background & Surface Colors
+
+| Variable | Default | Description |
+|---|---|---|
+| `--ds-bg-primary` | `#0d1117` | Main background, terminal background |
+| `--ds-bg-secondary` | `#161b22` | Tab bar, secondary surfaces |
+| `--ds-bg-tertiary` | `#21262d` | Hover states, input fields |
+| `--ds-selected-bg` | `#1f3a2e` | Selected/active tab background |
+
+### Border & Text
+
+| Variable | Default | Description |
+|---|---|---|
+| `--ds-border` | `#30363d` | Borders and dividers |
+| `--ds-text-primary` | `#c9d1d9` | Main text color |
+| `--ds-text-secondary` | `#8b949e` | Muted/secondary text |
+| `--ds-text-bright` | `#f0f6fc` | High-emphasis text |
+
+### Accent Colors
+
+| Variable | Default | Description |
+|---|---|---|
+| `--ds-accent-green` | `#238636` | Primary action buttons |
+| `--ds-accent-green-hover` | `#2ea043` | Button hover state |
+| `--ds-accent-green-active` | `#1a7f37` | Button active/pressed state |
+| `--ds-accent-green-soft` | `#3fb950` | Subtle green highlights |
+| `--ds-accent-red` | `#f85149` | Destructive actions, errors |
+| `--ds-accent-blue` | `#58a6ff` | Links, informational highlights |
+| `--ds-accent-orange` | `#f0883e` | Warnings, attention states |
+
+### Buttons
+
+| Variable | Default | Description |
+|---|---|---|
+| `--ds-btn-neutral` | `#30363d` | Neutral button background |
+| `--ds-btn-neutral-hover` | `#3d444d` | Neutral button hover |
+| `--ds-btn-neutral-active` | `#272c33` | Neutral button active |
+
+### Overlays & Shadows
+
+| Variable | Default | Description |
+|---|---|---|
+| `--ds-overlay` | `rgba(0, 0, 0, 0.7)` | Modal backdrop |
+| `--ds-shadow` | `rgba(0, 0, 0, 0.4)` | Drop shadows |
+| `--ds-reconnect-overlay` | `rgba(13, 17, 23, 0.75)` | Reconnecting overlay |
+| `--ds-reconnect-glow` | `rgba(240, 136, 62, 0.3)` | Reconnecting glow effect |
+| `--ds-refresh-glow` | `rgba(88, 166, 255, 0.3)` | Refresh glow effect |
+
+### Terminal Background Sync
+
+The xterm.js terminal background automatically syncs to `--ds-bg-primary`. When a theme changes, `updateTerminalTheme()` reads the computed value and applies it to the terminal instance — no page refresh needed.
+
+## Example: retro-monitor.css
+
+The built-in retro theme demonstrates how to go beyond simple color changes. It adds a CRT monitor bezel effect using body padding and inset shadows:
+
+```css
+:root {
+  --ds-bg-primary: #0a0a0a;
+  --ds-bg-secondary: #2a2a2a;
+  --ds-bg-tertiary: #3a3a3a;
+  --ds-border: #555;
+  --ds-text-primary: #d0d0d0;
+  --ds-text-secondary: #999;
+  --ds-text-bright: #fff;
+}
+
+/* Give tabs room to clear the rounded top corners */
+#tabs {
+  padding-top: 10px !important;
+  padding-left: 16px !important;
+  padding-right: 16px !important;
+}
+
+/* 90s CRT monitor bezel.
+ *
+ * Base CSS sets body to height:100vh, overflow:hidden, box-sizing:border-box.
+ * Adding padding shrinks the content area. #app-container base has height:100vh
+ * so we override to flex:1 to fill remaining space. All shadows must be inset
+ * since body overflow:hidden clips anything outside. */
+body {
+  background: #c8c0b8 !important;
+  display: flex !important;
+  flex-direction: column !important;
+  padding: 12px 25px 25px 25px;
+}
+
+#app-container {
+  flex: 1 !important;
+  min-height: 0 !important;
+  height: auto !important;
+  border-radius: 18px;
+  overflow: clip;
+  border: 4px solid #999;
+  box-shadow:
+    inset 0 0 0 2px #777,
+    inset 0 0 8px rgba(0,0,0,0.3);
+}
+```
+
+Key techniques:
+
+- **Body padding** creates the bezel — because `box-sizing: border-box` is set, padding shrinks the content area rather than expanding the page.
+- **`#app-container { flex: 1 }`** overrides the default `height: 100vh` so the container fills the remaining space after padding.
+- **Inset shadows only** — `body` has `overflow: hidden`, so any outset shadows or elements outside the viewport are clipped.
+- **`border-radius` on `#app-container`** rounds the screen corners. Use `overflow: clip` to ensure child content is clipped to the radius.
+
+## Tips
+
+- Use `!important` for non-variable overrides (e.g. `body { background: red !important; }`) since the base stylesheet uses specific selectors.
+- All shadows must be `inset` — `body` has `overflow: hidden`, so outset shadows are invisible.
+- When adding `body` padding, override `#app-container` height from `100vh` to `flex: 1` so the content still fills the viewport.
+- A minimal theme only needs a `:root` block with color overrides — no structural CSS required.


### PR DESCRIPTION
## Summary
- Add `docs/themes.md` — CSS variables reference, retro-monitor example, tips
- Add `docs/mods.md` — mod.json reference, bridge API, MCP tools, lifecycle
- Simplify README Themes/Mods sections to link to the new guides

Closes #113

## Test plan
- [ ] Verify all links in README resolve to the new docs
- [ ] Verify CSS variable list matches `public/css/styles.css:1-26`
- [ ] Verify bridge API methods match `public/js/mod-manager.js:830-906`
- [ ] Verify mod.json fields match actual mod manifests in repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)