### PR TITLE
Isolate recursive DeepSteve windows in Baby Browser

### DIFF
--- a/mods/firefox-extension/index.html
+++ b/mods/firefox-extension/index.html
@@ -74,7 +74,8 @@
   <iframe id="browser" sandbox="allow-same-origin allow-scripts allow-forms allow-popups"></iframe>
 
   <script>
-    const STORAGE_KEY = 'baby-browser-state';
+    let _d=0;try{let w=window;while(w!==w.parent){w=w.parent;_d++}}catch{}
+    const STORAGE_KEY = (_d > 0 ? 'ds'+_d+'-' : '') + 'baby-browser-state';
     const urlInput = document.getElementById('url');
     const goBtn = document.getElementById('go');
     const backBtn = document.getElementById('back');

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -14,6 +14,7 @@ import { initLiveReload } from './live-reload.js';
 import { ModManager } from './mod-manager.js';
 import { initFileDrop } from './file-drop.js';
 import { init as initCmdTabSwitch, setEnabled as setCmdTabSwitchEnabled, setHoldMs as setCmdTabSwitchHoldMs } from './cmd-tab-switch.js';
+import { nsKey } from './storage-namespace.js';
 
 // Configuration
 let maxIssueTitleLength = 25;
@@ -36,7 +37,7 @@ const processedBrowserRequests = new Set();
  * Survives page refresh, doesn't depend on localStorage window-ID mapping.
  */
 const TabSessions = {
-  KEY: 'deepsteve-tab-sessions',
+  KEY: nsKey('deepsteve-tab-sessions'),
   get() {
     try { return JSON.parse(sessionStorage.getItem(this.KEY)) || []; } catch { return []; }
   },
@@ -62,7 +63,7 @@ const TabSessions = {
  * Persist the active tab ID in sessionStorage so it survives page refresh.
  */
 const ActiveTab = {
-  KEY: 'deepsteve-active-tab',
+  KEY: nsKey('deepsteve-active-tab'),
   get() { return sessionStorage.getItem(this.KEY); },
   set(id) { sessionStorage.setItem(this.KEY, id); },
   clear() { sessionStorage.removeItem(this.KEY); }
@@ -1896,8 +1897,8 @@ async function init() {
   // Check if this is an existing tab BEFORE starting heartbeat (which creates window ID)
   const isExistingTab = WindowManager.hasExistingWindowId();
   console.log('[init] isExistingTab:', isExistingTab);
-  console.log('[init] sessionStorage windowId:', sessionStorage.getItem('deepsteve-window-id'));
-  console.log('[init] localStorage:', localStorage.getItem('deepsteve'));
+  console.log('[init] sessionStorage windowId:', sessionStorage.getItem(nsKey('deepsteve-window-id')));
+  console.log('[init] localStorage:', localStorage.getItem(nsKey('deepsteve')));
 
   // Check for legacy storage format and migrate
   const legacySessions = SessionStore.migrateFromLegacy();

--- a/public/js/layout-manager.js
+++ b/public/js/layout-manager.js
@@ -2,7 +2,9 @@
  * Layout management for horizontal/vertical tab layouts
  */
 
-const STORAGE_KEY = 'deepsteve-layout';
+import { nsKey } from './storage-namespace.js';
+
+const STORAGE_KEY = nsKey('deepsteve-layout');
 const MIN_SIDEBAR_WIDTH = 60;
 const DEFAULT_SIDEBAR_WIDTH = 200;
 

--- a/public/js/live-reload.js
+++ b/public/js/live-reload.js
@@ -11,6 +11,8 @@
  * Leader election: when multiple windows exist, lowest windowId shows the modal.
  */
 
+import { nsChannel } from './storage-namespace.js';
+
 const State = {
   CONNECTED: 'connected',
   CONFIRMING: 'confirming',
@@ -25,7 +27,7 @@ export function initLiveReload({ onMessage, onShowRestartConfirm, onShowReloadOv
   let pingTimer = null;
   let lastPingTime = 0;
 
-  const restartChannel = new BroadcastChannel('deepsteve-restart');
+  const restartChannel = new BroadcastChannel(nsChannel('deepsteve-restart'));
 
   function setState(newState) {
     console.log(`[live-reload] ${state} → ${newState}`);

--- a/public/js/mod-manager.js
+++ b/public/js/mod-manager.js
@@ -10,10 +10,12 @@
  * Only one panel is visible at a time; clicking a different tab switches to it.
  */
 
-const STORAGE_KEY = 'deepsteve-enabled-mods'; // Set of enabled mod IDs
-const ACTIVE_VIEW_KEY = 'deepsteve-active-mod-view'; // Which mod view is currently showing
-const PANEL_VISIBLE_KEY = 'deepsteve-panel-visible'; // Whether the panel is shown
-const ACTIVE_PANEL_KEY = 'deepsteve-active-panel'; // Which panel tab is active
+import { nsKey } from './storage-namespace.js';
+
+const STORAGE_KEY = nsKey('deepsteve-enabled-mods'); // Set of enabled mod IDs
+const ACTIVE_VIEW_KEY = nsKey('deepsteve-active-mod-view'); // Which mod view is currently showing
+const PANEL_VISIBLE_KEY = nsKey('deepsteve-panel-visible'); // Whether the panel is shown
+const ACTIVE_PANEL_KEY = nsKey('deepsteve-active-panel'); // Which panel tab is active
 
 let allMods = [];          // [{ id, name, description, entry, toolbar }]
 let enabledMods = new Set(); // mod IDs that are enabled
@@ -48,7 +50,7 @@ let getActiveSessionIdFn = null;     // set from appHooks
 let deepsteveVersion = null;   // set from /api/mods response
 let panelWidth = 360;
 const MIN_PANEL_WIDTH = 200;
-const PANEL_STORAGE_KEY = 'deepsteve-panel-width';
+const PANEL_STORAGE_KEY = nsKey('deepsteve-panel-width');
 
 // ─── Dependency helpers ──────────────────────────────────────────────
 
@@ -220,7 +222,7 @@ function _loadModSettings(mod) {
     defaults[s.key] = s.default;
   }
   try {
-    const stored = JSON.parse(localStorage.getItem(`deepsteve-mod-settings-${mod.id}`));
+    const stored = JSON.parse(localStorage.getItem(nsKey(`deepsteve-mod-settings-${mod.id}`)));
     if (stored) return { ...defaults, ...stored };
   } catch {}
   return defaults;
@@ -234,7 +236,7 @@ function _saveModSetting(modId, key, value) {
   if (!mod) return;
   const current = _loadModSettings(mod);
   current[key] = value;
-  localStorage.setItem(`deepsteve-mod-settings-${modId}`, JSON.stringify(current));
+  localStorage.setItem(nsKey(`deepsteve-mod-settings-${modId}`), JSON.stringify(current));
   _notifySettingsChanged(modId);
 }
 

--- a/public/js/session-store.js
+++ b/public/js/session-store.js
@@ -15,7 +15,9 @@
  * }
  */
 
-const STORAGE_KEY = 'deepsteve';
+import { nsKey } from './storage-namespace.js';
+
+const STORAGE_KEY = nsKey('deepsteve');
 
 function getStorage() {
   try {

--- a/public/js/storage-namespace.js
+++ b/public/js/storage-namespace.js
@@ -1,0 +1,33 @@
+/**
+ * Storage namespace isolation for recursive DeepSteve windows.
+ *
+ * When DeepSteve is opened inside its own Baby Browser proxy, the inner
+ * instance shares the same origin and therefore the same sessionStorage,
+ * localStorage, and BroadcastChannel namespace. We detect iframe nesting
+ * depth and prefix all keys so each level gets its own isolated state.
+ *
+ * Depth 0 (top-level) uses no prefix — fully backward compatible.
+ */
+
+let recursionDepth = 0;
+try {
+  let w = window;
+  while (w !== w.parent) {
+    w = w.parent;
+    recursionDepth++;
+  }
+} catch {
+  // cross-origin parent — treat current depth as final
+}
+
+const prefix = recursionDepth > 0 ? `ds${recursionDepth}-` : '';
+
+export function nsKey(key) {
+  return prefix + key;
+}
+
+export function nsChannel(name) {
+  return prefix + name;
+}
+
+export { recursionDepth };

--- a/public/js/window-manager.js
+++ b/public/js/window-manager.js
@@ -4,9 +4,10 @@
  */
 
 import { SessionStore } from './session-store.js';
+import { nsKey, nsChannel } from './storage-namespace.js';
 
-const WINDOW_ID_KEY = 'deepsteve-window-id';
-const CHANNEL_NAME = 'deepsteve-windows';
+const WINDOW_ID_KEY = nsKey('deepsteve-window-id');
+const CHANNEL_NAME = nsChannel('deepsteve-windows');
 const HEARTBEAT_INTERVAL = 5000;
 const ORPHAN_DETECTION_TIMEOUT = 1500;
 const LIVE_WINDOW_STALE_MS = 15000;


### PR DESCRIPTION
## Summary

When DeepSteve is opened inside its own Baby Browser proxy, the inner instance shares `sessionStorage`, `localStorage`, and `BroadcastChannel` with the outer window (same origin due to `sandbox="allow-same-origin"`). This causes the inner DeepSteve to mirror the outer one's tabs, participate in its orphan detection heartbeats, and corrupt shared state.

- Detect iframe nesting depth at boot by walking `window.parent`
- Prefix all storage keys and BroadcastChannel names with `ds{depth}-` (e.g. `ds1-deepsteve-tab-sessions`)
- Depth 0 (top-level) uses no prefix — fully backward compatible, no migration needed

## Test plan

- [ ] Open DeepSteve normally — verify sessions, tabs, persistence work as before; storage keys have no prefix in DevTools
- [ ] Open Baby Browser mod → navigate to `http://localhost:3000` — verify inner DeepSteve shows a fresh empty tab bar, not the outer sessions; inner keys have `ds1-` prefix
- [ ] Create a session in the inner DeepSteve — confirm it doesn't appear in the outer tab bar
- [ ] Refresh the inner page — confirm its sessions persist independently
- [ ] Open a third level (Baby Browser inside inner DeepSteve → localhost:3000) — verify `ds2-` prefixed keys and independent state

🤖 Generated with [Claude Code](https://claude.com/claude-code)