### PR TITLE
Add @mention awakening for agent chat (#197)

### DIFF
--- a/mods/agent-chat/tools.js
+++ b/mods/agent-chat/tools.js
@@ -47,9 +47,44 @@ function saveData() {
 
 function ensureChannel(name) {
   if (!data.channels[name]) {
-    data.channels[name] = { messages: [] };
+    data.channels[name] = { messages: [], participants: {} };
+  }
+  if (!data.channels[name].participants) {
+    data.channels[name].participants = {};
   }
   return data.channels[name];
+}
+
+function processAtMentions(channelName, text, context) {
+  const mentionPattern = /(?:^|\s)@(\S+)/g;
+  let match;
+  while ((match = mentionPattern.exec(text)) !== null) {
+    const name = match[1];
+    const ch = data.channels[channelName];
+    if (!ch || !ch.participants[name]) continue;
+
+    const sessionId = ch.participants[name];
+    const entry = context.shells.get(sessionId);
+    if (!entry) {
+      // Stale participant — clean up
+      delete ch.participants[name];
+      saveData();
+      continue;
+    }
+
+    if (entry.waitingForInput) {
+      entry.waitingForInput = false;
+      const stateMsg = JSON.stringify({ type: 'state', waiting: false });
+      entry.clients.forEach((c) => c.send(stateMsg));
+      setTimeout(() => context.submitToShell(entry.shell, '/chat #' + channelName), 500);
+    } else {
+      // Agent is busy — queue for when it next hits BEL
+      if (!entry.pendingChatAwaken) entry.pendingChatAwaken = [];
+      if (!entry.pendingChatAwaken.some(p => p.channel === channelName)) {
+        entry.pendingChatAwaken.push({ channel: channelName });
+      }
+    }
+  }
 }
 
 /**
@@ -69,10 +104,14 @@ function init(context) {
         channel: z.string().optional().describe('Channel name (defaults to "general")'),
         sender: z.string().describe('Your name/identifier as the sender'),
         text: z.string().describe('The message content'),
+        session_id: z.string().optional().describe('Your session ID from $DEEPSTEVE_SESSION_ID — enables @mention awakening'),
       },
-      handler: async ({ channel, sender, text }) => {
+      handler: async ({ channel, sender, text, session_id }) => {
         const channelName = channel || 'general';
         const ch = ensureChannel(channelName);
+        if (session_id) {
+          ch.participants[sender] = session_id;
+        }
         const msg = {
           id: data.nextId++,
           sender,
@@ -82,6 +121,7 @@ function init(context) {
         ch.messages.push(msg);
         saveData();
         broadcastChat();
+        processAtMentions(channelName, text, context);
         return { content: [{ type: 'text', text: `Message #${msg.id} sent to #${channelName}` }] };
       },
     },
@@ -185,6 +225,7 @@ function registerRoutes(app, context) {
     ch.messages.push(msg);
     saveData();
     broadcastChat();
+    processAtMentions(channelName, text, context);
     res.json({ message: msg });
   });
 

--- a/server.js
+++ b/server.js
@@ -713,6 +713,12 @@ function wireShellOutput(id) {
           e.initialPrompt = null;
           e.waitingForInput = false;
           setTimeout(() => submitToShell(e.shell, prompt), 500);
+        } else if (e.pendingChatAwaken?.length) {
+          const pending = e.pendingChatAwaken.shift();
+          e.waitingForInput = false;
+          const stateMsg = JSON.stringify({ type: 'state', waiting: false });
+          e.clients.forEach((c) => c.send(stateMsg));
+          setTimeout(() => submitToShell(e.shell, '/chat #' + pending.channel), 500);
         }
       } else if (!data.includes('\x07') && e.waitingForInput) {
         // PTY produced non-BEL output while we thought Claude was waiting —

--- a/skills/chat.md
+++ b/skills/chat.md
@@ -31,6 +31,7 @@ For continuous monitoring, use `/loop` to run `/chat` on an interval:
 
 ## Guidelines
 
+- When sending messages, include your `session_id` by reading `$DEEPSTEVE_SESSION_ID` (e.g. `echo $DEEPSTEVE_SESSION_ID`) and passing it to `send_message`. This enables @mention awakening — other agents or humans can `@your-name` to re-activate you.
 - When sending messages, be concise and helpful. Sign off with your session's tab name if relevant.
 - If you have context/task instructions, prioritize those when deciding how to respond.
 - Don't flood the channel — only send messages when you have something useful to contribute.


### PR DESCRIPTION
## Summary
- Agents register themselves (sender name + session ID) when sending chat messages via `send_message`
- `@name` mentions in chat messages look up the participant registry and either submit `/chat #channel` to the agent's PTY immediately (if idle/waiting) or queue to `pendingChatAwaken` (drained on next BEL)
- Stale participant entries are cleaned up when the session no longer exists

## Files changed
- `mods/agent-chat/tools.js` — participant registry, `processAtMentions()` helper, `session_id` param on `send_message`
- `server.js` — BEL handler drains `pendingChatAwaken` queue
- `skills/chat.md` — instructs agents to pass `session_id` when sending messages

## Test plan
- [ ] Start two agent sessions (A and B)
- [ ] Have A run `/loop 10s /chat #test` and send a message (registers itself)
- [ ] Let A's loop end, then from B or browser UI send `@A-name` to #test
- [ ] Verify A's PTY receives `/chat #test`
- [ ] Test busy case: @mention while agent is mid-task, verify it queues and fires on next BEL
- [ ] Test stale case: close A's session, send @mention, verify participant entry is cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)