### PR TITLE
Add missing mod.json for display-tab mod

### DIFF
--- a/mods/display-tab/mod.json
+++ b/mods/display-tab/mod.json
@@ -1,0 +1,11 @@
+{
+  "name": "Display Tab",
+  "version": "0.1.0",
+  "enabledByDefault": true,
+  "description": "MCP tools for creating, updating, and closing HTML display tabs in the browser",
+  "tools": [
+    { "name": "create_display_tab", "description": "Create a new browser tab displaying arbitrary HTML content" },
+    { "name": "update_display_tab", "description": "Update the HTML content of an existing display tab" },
+    { "name": "close_display_tab", "description": "Close a display tab" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `mods/display-tab/mod.json` with name, version, description, and tool declarations
- The display-tab mod had only `tools.js`, causing `validate-mods.js` to fail with "missing mod.json"

Fixes #267

## Test plan
- [x] `node validate-mods.js` exits 0 with "All 18 mods validated successfully."

🤖 Generated with [Claude Code](https://claude.com/claude-code)