### PR TITLE
Pluggable engine interface with tmux backend

### DIFF
--- a/engines/engine.js
+++ b/engines/engine.js
@@ -1,0 +1,70 @@
+const EventEmitter = require('events');
+
+/**
+ * Base class for terminal engine backends.
+ * Each engine manages terminal sessions by ID, emitting 'data' and 'exit' events.
+ *
+ * Events:
+ *   'data' (id, data)          — terminal output from session
+ *   'exit' (id, exitCode, signal) — session process exited
+ */
+class Engine extends EventEmitter {
+  /**
+   * Start a new terminal session.
+   * @param {string} id - Session ID
+   * @param {string} cmd - Command to run (e.g. 'zsh')
+   * @param {string[]} args - Command arguments
+   * @param {string} cwd - Working directory
+   * @param {{ cols: number, rows: number, env: object }} opts
+   */
+  spawn(id, cmd, args, cwd, opts) {
+    throw new Error('spawn() not implemented');
+  }
+
+  /** Write data to a session's stdin. */
+  write(id, data) {
+    throw new Error('write() not implemented');
+  }
+
+  /** Resize a session's terminal. */
+  resize(id, cols, rows) {
+    throw new Error('resize() not implemented');
+  }
+
+  /** Send a signal to a session's process. */
+  kill(id, signal) {
+    throw new Error('kill() not implemented');
+  }
+
+  /** Get the PID of a session's process. Returns null if not found. */
+  getPid(id) {
+    throw new Error('getPid() not implemented');
+  }
+
+  /** Clean up a session (remove from internal tracking). */
+  destroy(id) {
+    throw new Error('destroy() not implemented');
+  }
+
+  /** Register an exit handler for a session. */
+  onExit(id, callback) {
+    throw new Error('onExit() not implemented');
+  }
+
+  /** Remove a specific data listener for a session. */
+  removeDataListener(id, handler) {
+    throw new Error('removeDataListener() not implemented');
+  }
+
+  /** Check if a session exists in this engine. */
+  has(id) {
+    return false;
+  }
+
+  /** List all managed session IDs. */
+  listSessions() {
+    return [];
+  }
+}
+
+module.exports = Engine;

--- a/engines/node-pty.js
+++ b/engines/node-pty.js
@@ -1,0 +1,88 @@
+const pty = require('node-pty');
+const Engine = require('./engine');
+
+/**
+ * node-pty engine — spawns PTY processes directly.
+ * This is the default engine, extracted from the original inline code in server.js.
+ */
+class NodePtyEngine extends Engine {
+  constructor() {
+    super();
+    this._ptys = new Map(); // id → { pty, exitCallbacks }
+  }
+
+  spawn(id, cmd, args, cwd, { cols = 120, rows = 40, env } = {}) {
+    const p = pty.spawn(cmd, args, {
+      name: 'xterm-256color',
+      cols,
+      rows,
+      cwd,
+      env: env || process.env,
+    });
+
+    const entry = { pty: p, exitCallbacks: [] };
+    this._ptys.set(id, entry);
+
+    p.onData((data) => {
+      this.emit('data', id, data);
+    });
+
+    p.onExit(({ exitCode, signal }) => {
+      for (const cb of entry.exitCallbacks) {
+        try { cb({ exitCode, signal }); } catch {}
+      }
+      this.emit('exit', id, exitCode, signal);
+    });
+  }
+
+  write(id, data) {
+    const entry = this._ptys.get(id);
+    if (entry) entry.pty.write(data);
+  }
+
+  resize(id, cols, rows) {
+    const entry = this._ptys.get(id);
+    if (entry) entry.pty.resize(cols, rows);
+  }
+
+  kill(id, signal) {
+    const entry = this._ptys.get(id);
+    if (!entry) return;
+    const pid = entry.pty.pid;
+    // Try process group kill first, fall back to pty.kill
+    try {
+      process.kill(-pid, signal);
+    } catch {
+      try { entry.pty.kill(signal); } catch {}
+    }
+  }
+
+  getPid(id) {
+    const entry = this._ptys.get(id);
+    return entry ? entry.pty.pid : null;
+  }
+
+  destroy(id) {
+    this._ptys.delete(id);
+  }
+
+  onExit(id, callback) {
+    const entry = this._ptys.get(id);
+    if (entry) entry.exitCallbacks.push(callback);
+  }
+
+  removeDataListener(id, handler) {
+    const entry = this._ptys.get(id);
+    if (entry) entry.pty.removeListener('data', handler);
+  }
+
+  has(id) {
+    return this._ptys.has(id);
+  }
+
+  listSessions() {
+    return [...this._ptys.keys()];
+  }
+}
+
+module.exports = NodePtyEngine;

--- a/engines/tmux.js
+++ b/engines/tmux.js
@@ -1,0 +1,253 @@
+const pty = require('node-pty');
+const { execSync } = require('child_process');
+const Engine = require('./engine');
+
+const SESSION_PREFIX = 'ds-';
+
+/**
+ * tmux engine — each session runs inside a tmux session named ds-{id}.
+ * A node-pty is used to `tmux attach-session` for I/O streaming, so all
+ * PTY output (escape sequences, BEL detection) works unchanged.
+ *
+ * tmux sessions survive daemon restarts; on startup, listSessions() returns
+ * surviving sessions that can be reattached.
+ */
+class TmuxEngine extends Engine {
+  constructor() {
+    super();
+    this._sessions = new Map(); // id → { attachPty, exitCallbacks }
+    this._tmuxVersion = null;
+    this._checkTmux();
+  }
+
+  _checkTmux() {
+    try {
+      const out = execSync("zsh -l -c 'tmux -V'", { encoding: 'utf8', timeout: 5000 }).trim();
+      const match = out.match(/(\d+\.\d+)/);
+      this._tmuxVersion = match ? match[1] : out;
+    } catch {
+      this._tmuxVersion = null;
+    }
+  }
+
+  get available() {
+    return this._tmuxVersion !== null;
+  }
+
+  get version() {
+    return this._tmuxVersion;
+  }
+
+  /** Check if tmux supports -e flag (>= 3.2) */
+  get _supportsEnvFlag() {
+    if (!this._tmuxVersion) return false;
+    const parts = this._tmuxVersion.split('.').map(Number);
+    return parts[0] > 3 || (parts[0] === 3 && parts[1] >= 2);
+  }
+
+  _tmuxSessionName(id) {
+    return SESSION_PREFIX + id;
+  }
+
+  spawn(id, cmd, args, cwd, { cols = 120, rows = 40, env } = {}) {
+    const sessionName = this._tmuxSessionName(id);
+
+    // Build the command string
+    const quoted = args.map(a => `'${a.replace(/'/g, "'\\''")}'`).join(' ');
+    const fullCmd = `${cmd} ${quoted}`;
+
+    // Build tmux new-session command
+    const tmuxArgs = [
+      'new-session', '-d',
+      '-s', sessionName,
+      '-x', String(cols),
+      '-y', String(rows),
+      '-c', cwd,
+    ];
+
+    // Pass environment variables
+    const extraEnv = {};
+    if (env) {
+      // Collect env vars that differ from process.env
+      for (const [key, val] of Object.entries(env)) {
+        if (val !== undefined && val !== process.env[key]) {
+          extraEnv[key] = val;
+        }
+      }
+    }
+
+    if (this._supportsEnvFlag) {
+      // tmux >= 3.2: use -e KEY=VAL
+      for (const [key, val] of Object.entries(extraEnv)) {
+        tmuxArgs.push('-e', `${key}=${val}`);
+      }
+      tmuxArgs.push(fullCmd);
+    } else {
+      // Older tmux: wrap with env command
+      const envPrefix = Object.entries(extraEnv)
+        .map(([k, v]) => `${k}='${v.replace(/'/g, "'\\''")}'`)
+        .join(' ');
+      tmuxArgs.push(envPrefix ? `env ${envPrefix} ${fullCmd}` : fullCmd);
+    }
+
+    // Create the tmux session
+    try {
+      execSync(`zsh -l -c 'tmux ${tmuxArgs.map(a => `"${a.replace(/"/g, '\\"')}"`).join(' ')}'`, {
+        timeout: 10000,
+        stdio: 'pipe',
+      });
+    } catch (e) {
+      throw new Error(`Failed to create tmux session ${sessionName}: ${e.message}`);
+    }
+
+    // Attach to the tmux session via a PTY for I/O
+    this._attach(id, cols, rows);
+  }
+
+  _attach(id, cols, rows) {
+    const sessionName = this._tmuxSessionName(id);
+    const attachPty = pty.spawn('tmux', ['attach-session', '-t', sessionName], {
+      name: 'xterm-256color',
+      cols: cols || 120,
+      rows: rows || 40,
+    });
+
+    const entry = { attachPty, exitCallbacks: [] };
+    this._sessions.set(id, entry);
+
+    attachPty.onData((data) => {
+      this.emit('data', id, data);
+    });
+
+    attachPty.onExit(({ exitCode, signal }) => {
+      // Check if the tmux session is still alive
+      const alive = this._tmuxSessionAlive(id);
+      if (alive) {
+        // Attach PTY died but tmux session lives — could reattach later
+        // For now, treat as exit since the engine consumer expects it
+      }
+      for (const cb of entry.exitCallbacks) {
+        try { cb({ exitCode, signal }); } catch {}
+      }
+      this.emit('exit', id, exitCode, signal);
+    });
+  }
+
+  /** Reattach to an existing tmux session (e.g. after daemon restart). */
+  reattach(id, cols, rows) {
+    if (!this._tmuxSessionAlive(id)) return false;
+    this._attach(id, cols, rows);
+    return true;
+  }
+
+  _tmuxSessionAlive(id) {
+    const sessionName = this._tmuxSessionName(id);
+    try {
+      execSync(`zsh -l -c 'tmux has-session -t "${sessionName}"'`, { timeout: 5000, stdio: 'pipe' });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  write(id, data) {
+    const entry = this._sessions.get(id);
+    if (entry) entry.attachPty.write(data);
+  }
+
+  resize(id, cols, rows) {
+    const entry = this._sessions.get(id);
+    if (!entry) return;
+    const sessionName = this._tmuxSessionName(id);
+    try {
+      execSync(`zsh -l -c 'tmux resize-window -t "${sessionName}" -x ${cols} -y ${rows}'`, { timeout: 5000, stdio: 'pipe' });
+    } catch {}
+    try {
+      entry.attachPty.resize(cols, rows);
+    } catch {}
+  }
+
+  kill(id, signal) {
+    const sessionName = this._tmuxSessionName(id);
+    // Try to get the pane PID and kill the process group
+    try {
+      const pid = this._getPanePid(id);
+      if (pid) {
+        try { process.kill(-pid, signal); } catch {}
+        return;
+      }
+    } catch {}
+    // Fallback: kill the tmux session
+    try {
+      execSync(`zsh -l -c 'tmux kill-session -t "${sessionName}"'`, { timeout: 5000, stdio: 'pipe' });
+    } catch {}
+  }
+
+  _getPanePid(id) {
+    const sessionName = this._tmuxSessionName(id);
+    try {
+      const out = execSync(`zsh -l -c 'tmux display-message -t "${sessionName}" -p "#{pane_pid}"'`, {
+        encoding: 'utf8', timeout: 5000, stdio: 'pipe',
+      }).trim();
+      return parseInt(out, 10) || null;
+    } catch {
+      return null;
+    }
+  }
+
+  getPid(id) {
+    return this._getPanePid(id);
+  }
+
+  destroy(id) {
+    const entry = this._sessions.get(id);
+    if (entry) {
+      try { entry.attachPty.kill(); } catch {}
+    }
+    this._sessions.delete(id);
+    // Kill the tmux session if still alive
+    const sessionName = this._tmuxSessionName(id);
+    try {
+      execSync(`zsh -l -c 'tmux kill-session -t "${sessionName}"'`, { timeout: 5000, stdio: 'pipe' });
+    } catch {}
+  }
+
+  onExit(id, callback) {
+    const entry = this._sessions.get(id);
+    if (entry) entry.exitCallbacks.push(callback);
+  }
+
+  removeDataListener(id, handler) {
+    const entry = this._sessions.get(id);
+    if (entry) entry.attachPty.removeListener('data', handler);
+  }
+
+  has(id) {
+    return this._sessions.has(id);
+  }
+
+  /**
+   * List all tmux sessions with the ds- prefix.
+   * Returns session IDs (without the prefix).
+   */
+  listSessions() {
+    try {
+      const out = execSync("zsh -l -c 'tmux list-sessions -F \"#{session_name}\"'", {
+        encoding: 'utf8', timeout: 5000, stdio: 'pipe',
+      }).trim();
+      if (!out) return [];
+      return out.split('\n')
+        .filter(name => name.startsWith(SESSION_PREFIX))
+        .map(name => name.slice(SESSION_PREFIX.length));
+    } catch {
+      return [];
+    }
+  }
+
+  /** Check if a specific session can be reattached. */
+  canReattach(id) {
+    return this._tmuxSessionAlive(id);
+  }
+}
+
+module.exports = TmuxEngine;

--- a/mods/deepsteve-core/tools.js
+++ b/mods/deepsteve-core/tools.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 function init(context) {
   const {
-    shells, closeSession, spawnAgent, getSpawnArgs, getAgentConfig, wireShellOutput,
+    shells, closeSession, spawnSession, engine, getSpawnArgs, getAgentConfig, wireShellOutput,
     watchClaudeSessionDir, unwatchClaudeSessionDir, saveState,
     validateWorktree, ensureWorktree, submitToShell,
     fetchIssueFromGitHub, deliverPromptWhenReady,
@@ -143,9 +143,9 @@ function init(context) {
         const name = tabTitle.length <= maxLen ? tabTitle : tabTitle.slice(0, maxLen) + '\u2026';
 
         log(`[MCP] start_issue #${number}: id=${id}, agent=${effectiveAgentType}, worktree=${worktree || 'none'}, cwd=${spawnCwd}`);
-        const shell = spawnAgent(effectiveAgentType, spawnArgs, spawnCwd, { cols: 120, rows: 40, env: { DEEPSTEVE_SESSION_ID: id } });
+        spawnSession(id, effectiveAgentType, spawnArgs, spawnCwd, { cols: 120, rows: 40, env: { DEEPSTEVE_SESSION_ID: id } });
         shells.set(id, {
-          shell, clients: new Set(), cwd: spawnCwd,
+          clients: new Set(), cwd: spawnCwd,
           claudeSessionId, agentType: effectiveAgentType,
           worktree: worktree || null, windowId,
           name, initialPrompt: prompt,
@@ -156,11 +156,11 @@ function init(context) {
         // For non-BEL agents with a synchronous prompt, deliver after delay
         if (prompt && agentConfig.initialPromptDelay > 0) {
           shells.get(id).initialPrompt = null;
-          setTimeout(() => submitToShell(shell, prompt), agentConfig.initialPromptDelay);
+          setTimeout(() => submitToShell(id, prompt), agentConfig.initialPromptDelay);
         }
 
         if (agentConfig.supportsSessionWatch) watchClaudeSessionDir(id);
-        shell.onExit(() => {
+        engine.onExit(id, () => {
           if (agentConfig.supportsSessionWatch) unwatchClaudeSessionDir(id);
           if (!isShuttingDown()) { shells.delete(id); saveState(); }
         });
@@ -233,9 +233,9 @@ function init(context) {
         const tabName = name || (validatedWorktree ? validatedWorktree : undefined);
 
         log(`[MCP] open_terminal: id=${id}, agent=${effectiveAgentType}, worktree=${validatedWorktree || 'none'}, cwd=${spawnCwd}, caller=${session_id}`);
-        const shell = spawnAgent(effectiveAgentType, spawnArgs, spawnCwd, { cols: 120, rows: 40, env: { DEEPSTEVE_SESSION_ID: id } });
+        spawnSession(id, effectiveAgentType, spawnArgs, spawnCwd, { cols: 120, rows: 40, env: { DEEPSTEVE_SESSION_ID: id } });
         shells.set(id, {
-          shell, clients: new Set(), cwd: spawnCwd,
+          clients: new Set(), cwd: spawnCwd,
           claudeSessionId, agentType: effectiveAgentType,
           worktree: validatedWorktree, windowId,
           name: tabName, initialPrompt: prompt || null,
@@ -246,11 +246,11 @@ function init(context) {
         // For non-BEL agents, deliver initialPrompt after delay
         if (prompt && agentConfig.initialPromptDelay > 0) {
           shells.get(id).initialPrompt = null;
-          setTimeout(() => submitToShell(shell, prompt), agentConfig.initialPromptDelay);
+          setTimeout(() => submitToShell(id, prompt), agentConfig.initialPromptDelay);
         }
 
         if (agentConfig.supportsSessionWatch) watchClaudeSessionDir(id);
-        shell.onExit(() => {
+        engine.onExit(id, () => {
           if (agentConfig.supportsSessionWatch) unwatchClaudeSessionDir(id);
           if (!isShuttingDown()) { shells.delete(id); saveState(); }
         });

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -419,11 +419,12 @@ async function refreshSessionsDropdown() {
 const settingsBtn = document.getElementById('settings-btn');
 
 settingsBtn?.addEventListener('click', async () => {
-  const [settingsData, themesData, versionData, defaultsData] = await Promise.all([
+  const [settingsData, themesData, versionData, defaultsData, enginesData] = await Promise.all([
     fetch('/api/settings').then(r => r.json()),
     fetch('/api/themes').then(r => r.json()),
     fetch('/api/version').then(r => r.json()).catch(() => ({ current: '?', latest: null, updateAvailable: false })),
-    fetch('/api/settings/defaults').then(r => r.json()).catch(() => ({}))
+    fetch('/api/settings/defaults').then(r => r.json()).catch(() => ({})),
+    fetch('/api/engines').then(r => r.json()).catch(() => ({ engines: [], current: 'node-pty' }))
   ]);
   const currentProfile = settingsData.shellProfile || '~/.zshrc';
   const currentMaxTitle = settingsData.maxIssueTitleLength || 25;
@@ -536,6 +537,18 @@ settingsBtn?.addEventListener('click', async () => {
           <label style="font-size: 12px; color: var(--ds-text-secondary);">Binary path</label>
           <input type="text" id="gemini-binary" value="${escapeHtml(currentGeminiBinary)}" placeholder="gemini" style="width: 200px; padding: 4px 8px; border-radius: 4px; border: 1px solid var(--ds-border); background: var(--ds-bg-secondary); color: var(--ds-text-primary);">
         </div>
+      </div>
+      <div class="settings-section">
+        <h3>Terminal Engine</h3>
+        <p style="font-size: 13px; color: var(--ds-text-secondary); margin-bottom: 8px;">
+          How terminal sessions are managed. tmux sessions survive daemon restarts.
+        </p>
+        <select id="engine-select" style="padding: 4px 8px; border-radius: 4px; border: 1px solid var(--ds-border); background: var(--ds-bg-secondary); color: var(--ds-text-primary);">
+          ${(enginesData.engines || []).map(e => {
+            const label = e.available ? `${e.name}${e.version ? ' v' + e.version : ''}` : `${e.name} (not installed)`;
+            return `<option value="${e.id}" ${e.id === enginesData.current ? 'selected' : ''} ${!e.available ? 'disabled' : ''}>${escapeHtml(label)}</option>`;
+          }).join('')}
+        </select>
       </div>
       </div>
       <div class="settings-tab-content" data-tab="github">
@@ -908,11 +921,25 @@ settingsBtn?.addEventListener('click', async () => {
     if (overlay.querySelector('#agent-gemini').checked) enabledAgents.push('gemini');
     const opencodeBinary = overlay.querySelector('#opencode-binary').value || 'opencode';
     const geminiBinary = overlay.querySelector('#gemini-binary').value || 'gemini';
-    await fetch('/api/settings', {
+    const selectedEngine = overlay.querySelector('#engine-select')?.value || 'node-pty';
+    const settingsPayload = { shellProfile, maxIssueTitleLength: newMaxTitle, wandPlanMode, wandPromptTemplate, symlinkWorktreeSettings, cmdTabSwitch, cmdTabSwitchHoldMs, enabledAgents, opencodeBinary, geminiBinary, windowConfigs: editingConfigs, engine: selectedEngine };
+    let resp = await fetch('/api/settings', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ shellProfile, maxIssueTitleLength: newMaxTitle, wandPlanMode, wandPromptTemplate, symlinkWorktreeSettings, cmdTabSwitch, cmdTabSwitchHoldMs, enabledAgents, opencodeBinary, geminiBinary, windowConfigs: editingConfigs })
+      body: JSON.stringify(settingsPayload)
     });
+    let result = await resp.json();
+    if (result.engineSwitchRequired) {
+      const confirmed = confirm(`Switching engines will close ${result.activeSessions} active session(s). Continue?`);
+      if (confirmed) {
+        resp = await fetch('/api/settings', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...settingsPayload, engineSwitchConfirm: true })
+        });
+        result = await resp.json();
+      }
+    }
     maxIssueTitleLength = Math.max(10, Math.min(200, newMaxTitle));
     setCmdHoldModeEnabled(cmdTabSwitch);
     setCmdHoldModeHoldMs(cmdTabSwitchHoldMs);
@@ -945,6 +972,47 @@ function updateAppBadge() {
  */
 function getWindowId() {
   return WindowManager.getWindowId();
+}
+
+/**
+ * Attach to an existing tmux session (raw terminal)
+ */
+function createTmuxAttachSession(tmuxSessionName) {
+  const { cols, rows } = measureTerminalSize();
+  const ws = createWebSocket({
+    action: 'tmux-attach',
+    session: tmuxSessionName,
+    name: tmuxSessionName,
+    cols,
+    rows,
+    windowId: getWindowId(),
+  });
+
+  let pendingData = [];
+  let assignedId = null;
+
+  ws.onmessage = (e) => {
+    let msg;
+    try { msg = JSON.parse(e.data); } catch {
+      const session = assignedId && sessions.get(assignedId);
+      if (session) {
+        session.term.write(e.data);
+      } else {
+        pendingData.push(e.data);
+      }
+      return;
+    }
+
+    if (msg.type === 'session') {
+      assignedId = msg.id;
+      ws.setSessionId(msg.id);
+      initTerminal(msg.id, ws, null, msg.name || tmuxSessionName, { pendingData });
+      pendingData = [];
+    } else if (msg.type === 'error') {
+      alert(msg.message || 'Failed to attach to tmux session');
+      ws.close();
+    }
+  };
 }
 
 /**
@@ -1844,6 +1912,7 @@ function showNewTabMenu(e) {
   html += `
     <div class="context-menu-item" data-action="worktree">New worktree...</div>
     <div class="context-menu-item" data-action="repo">New tab in repo...</div>
+    <div class="context-menu-item context-menu-has-submenu" id="tmux-attach-trigger">Attach tmux session <span class="context-menu-arrow"></span></div>
   `;
 
   // Add mod tab items
@@ -1915,6 +1984,72 @@ function showNewTabMenu(e) {
     });
   }
 
+  // Set up tmux attach submenu
+  const tmuxTrigger = menu.querySelector('#tmux-attach-trigger');
+  let tmuxSubmenu = null;
+  if (tmuxTrigger) {
+    let tmuxHideTimer = null;
+    const hideTmuxSubmenu = () => { if (tmuxSubmenu) { tmuxSubmenu.remove(); tmuxSubmenu = null; } };
+    const delayedHideTmux = () => { tmuxHideTimer = setTimeout(hideTmuxSubmenu, 100); };
+    const cancelHideTmux = () => { clearTimeout(tmuxHideTimer); };
+
+    const showTmuxSubmenu = async () => {
+      cancelHideTmux();
+      if (tmuxSubmenu) return;
+      tmuxSubmenu = document.createElement('div');
+      tmuxSubmenu.className = 'context-menu context-submenu';
+      tmuxSubmenu.innerHTML = '<div class="context-menu-item" style="opacity:0.5;pointer-events:none">Loading...</div>';
+      document.body.appendChild(tmuxSubmenu);
+      const triggerRect = tmuxTrigger.getBoundingClientRect();
+      tmuxSubmenu.style.left = (triggerRect.right + 2) + 'px';
+      tmuxSubmenu.style.top = triggerRect.top + 'px';
+
+      try {
+        const data = await fetch('/api/tmux-sessions').then(r => r.json());
+        if (!tmuxSubmenu) return; // closed while fetching
+        const sessions = data.sessions || [];
+        if (sessions.length === 0) {
+          tmuxSubmenu.innerHTML = '<div class="context-menu-item" style="opacity:0.5;pointer-events:none">No tmux sessions</div>';
+        } else {
+          tmuxSubmenu.innerHTML = sessions.map(s => {
+            const label = s.attached ? `${s.name} (attached)` : s.name;
+            return `<div class="context-menu-item" data-tmux-session="${s.name.replace(/"/g, '&quot;')}">${label}</div>`;
+          }).join('');
+          tmuxSubmenu.addEventListener('click', (ev) => {
+            const item = ev.target.closest('.context-menu-item');
+            if (!item || !item.dataset.tmuxSession) return;
+            ev.stopPropagation();
+            const sessionName = item.dataset.tmuxSession;
+            hideTmuxSubmenu();
+            menu.remove();
+            createTmuxAttachSession(sessionName);
+          });
+        }
+        // Reposition in case size changed
+        const subRect = tmuxSubmenu.getBoundingClientRect();
+        if (subRect.right > window.innerWidth) {
+          tmuxSubmenu.style.left = (triggerRect.left - subRect.width - 2) + 'px';
+        }
+        if (subRect.bottom > window.innerHeight) {
+          tmuxSubmenu.style.top = (window.innerHeight - subRect.height - 8) + 'px';
+        }
+      } catch {
+        if (tmuxSubmenu) tmuxSubmenu.innerHTML = '<div class="context-menu-item" style="opacity:0.5;pointer-events:none">tmux not available</div>';
+      }
+      if (tmuxSubmenu) {
+        tmuxSubmenu.addEventListener('mouseenter', cancelHideTmux);
+        tmuxSubmenu.addEventListener('mouseleave', delayedHideTmux);
+      }
+    };
+
+    tmuxTrigger.addEventListener('mouseenter', showTmuxSubmenu);
+    tmuxTrigger.addEventListener('mouseleave', delayedHideTmux);
+    tmuxTrigger.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      tmuxSubmenu ? hideTmuxSubmenu() : showTmuxSubmenu();
+    });
+  }
+
   // Position below the dropdown arrow button
   const btn = e.target.closest('#new-btn-dropdown') || e.target.closest('#new-btn-group');
   const rect = btn.getBoundingClientRect();
@@ -1978,6 +2113,7 @@ function showNewTabMenu(e) {
     }
     menu.remove();
     if (submenu) submenu.remove();
+    if (tmuxSubmenu) tmuxSubmenu.remove();
     cleanup();
     if (action === 'recent') {
       createSession(item.dataset.path, null, true, { agentType: getDefaultAgentType() });
@@ -2001,9 +2137,10 @@ function showNewTabMenu(e) {
     document.removeEventListener('mousedown', closeHandler);
   };
   const closeHandler = (ev) => {
-    if (!menu.contains(ev.target) && !(submenu && submenu.contains(ev.target)) && ev.target !== btn) {
+    if (!menu.contains(ev.target) && !(submenu && submenu.contains(ev.target)) && !(tmuxSubmenu && tmuxSubmenu.contains(ev.target)) && ev.target !== btn) {
       menu.remove();
       if (submenu) submenu.remove();
+      if (tmuxSubmenu) tmuxSubmenu.remove();
       cleanup();
     }
   };

--- a/public/js/ws-client.js
+++ b/public/js/ws-client.js
@@ -5,6 +5,8 @@
 export function createWebSocket(options = {}) {
   const params = new URLSearchParams();
 
+  if (options.action) params.set('action', options.action);
+  if (options.session) params.set('session', options.session);
   if (options.id) params.set('id', options.id);
   if (options.cwd) params.set('cwd', options.cwd);
   if (options.isNew) params.set('new', '1');
@@ -46,6 +48,8 @@ export function createWebSocket(options = {}) {
     // so future reconnections request the existing session instead of creating new ones.
     setSessionId(id) {
       const p = new URLSearchParams();
+      if (options.action) p.set('action', options.action);
+      if (options.session) p.set('session', options.session);
       p.set('id', id);
       if (options.cwd) p.set('cwd', options.cwd);
       if (options.cols) p.set('cols', options.cols);

--- a/release.sh
+++ b/release.sh
@@ -54,6 +54,7 @@ NODE_PATH=$(which node)
 
 mkdir -p "$INSTALL_DIR/public/js"
 mkdir -p "$INSTALL_DIR/public/css"
+mkdir -p "$INSTALL_DIR/engines"
 mkdir -p "$INSTALL_DIR/themes"
 mkdir -p "$INSTALL_DIR/skills"
 mkdir -p "$HOME/Library/LaunchAgents"
@@ -90,6 +91,11 @@ embed_text() {
 embed_text "package.json" "package.json"
 embed_text "server.js" "server.js"
 embed_text "mcp-server.js" "mcp-server.js"
+
+# Engine files
+embed_text "engines/engine.js" "engines/engine.js"
+embed_text "engines/node-pty.js" "engines/node-pty.js"
+embed_text "engines/tmux.js" "engines/tmux.js"
 
 # Public files
 embed_text "public/index.html" "public/index.html"

--- a/restart.sh
+++ b/restart.sh
@@ -33,6 +33,8 @@ cd "$SCRIPT_DIR"
 cp package.json ~/.deepsteve/
 cp server.js ~/.deepsteve/
 cp mcp-server.js ~/.deepsteve/
+mkdir -p ~/.deepsteve/engines
+cp engines/*.js ~/.deepsteve/engines/
 cp -r public/* ~/.deepsteve/public/
 mkdir -p ~/.deepsteve/themes
 cp -n themes/*.css ~/.deepsteve/themes/ 2>/dev/null || true

--- a/server.js
+++ b/server.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const https = require('https');
-const pty = require('node-pty');
 const { WebSocketServer } = require('ws');
 const { randomUUID } = require('crypto');
 const { execSync, execFileSync, exec } = require('child_process');
@@ -9,6 +8,8 @@ const path = require('path');
 const os = require('os');
 const net = require('net');
 const { initMCP } = require('./mcp-server');
+const NodePtyEngine = require('./engines/node-pty');
+const TmuxEngine = require('./engines/tmux');
 
 const PORT = process.env.PORT || 3000;
 
@@ -194,7 +195,8 @@ Please read the issue carefully, understand the codebase context, and implement 
   defaultAgent: 'claude',
   opencodeBinary: 'opencode',
   geminiBinary: 'gemini',
-  enabledAgents: ['claude', 'opencode']
+  enabledAgents: ['claude', 'opencode'],
+  engine: 'node-pty'
 };
 
 // Load settings
@@ -216,6 +218,25 @@ function saveSettings() {
     console.error('Failed to save settings:', e.message);
   }
 }
+
+// --- Engine initialization ---
+let engine;
+function initEngine() {
+  if (settings.engine === 'tmux') {
+    const tmux = new TmuxEngine();
+    if (tmux.available) {
+      engine = tmux;
+      log(`Engine: tmux v${tmux.version}`);
+      return;
+    }
+    log('Engine: tmux requested but not available, falling back to node-pty');
+    settings.engine = 'node-pty';
+    saveSettings();
+  }
+  engine = new NodePtyEngine();
+  log('Engine: node-pty');
+}
+initEngine();
 
 function getShellProfilePath() {
   let p = settings.shellProfile || '~/.zshrc';
@@ -374,6 +395,7 @@ function broadcastSettings() {
     cmdTabSwitchHoldMs: settings.cmdTabSwitchHoldMs,
     symlinkWorktreeSettings: settings.symlinkWorktreeSettings,
     windowConfigs: settings.windowConfigs || [],
+    engine: settings.engine || 'node-pty',
   });
   for (const client of wss.clients) {
     if (client.readyState === 1) client.send(msg);
@@ -406,52 +428,26 @@ function broadcastSkills() {
   }
 }
 
-// Spawn claude with full login shell environment (like iTerm does)
-function spawnClaude(args, cwd, { cols = 120, rows = 40, env: extraEnv } = {}) {
-  // Use login shell (-l) which properly sources /etc/zprofile, ~/.zprofile, ~/.zshrc
+/**
+ * Spawn a session using the active engine.
+ * @param {string} id - Session ID
+ * @param {string} agentType - 'claude', 'opencode', or 'gemini'
+ * @param {string[]} args - Agent CLI arguments
+ * @param {string} cwd - Working directory
+ * @param {{ cols?: number, rows?: number, env?: object }} opts
+ */
+function spawnSession(id, agentType, args, cwd, { cols = 120, rows = 40, env: extraEnv } = {}) {
+  const bin = agentType === 'claude' ? 'claude'
+    : agentType === 'opencode' ? (settings.opencodeBinary || 'opencode')
+    : (settings.geminiBinary || 'gemini');
   const quoted = args.map(a => `'${a.replace(/'/g, "'\\''")}'`).join(' ');
   const env = extraEnv ? { ...process.env, ...extraEnv } : process.env;
-  return pty.spawn('zsh', ['-l', '-c', `claude ${quoted}`], {
-    name: 'xterm-256color',
-    cols,
-    rows,
-    cwd,
-    env
-  });
-}
-
-// Spawn opencode with full login shell environment
-function spawnOpenCode(args, cwd, { cols = 120, rows = 40, env: extraEnv } = {}) {
-  const bin = settings.opencodeBinary || 'opencode';
-  const quoted = args.map(a => `'${a.replace(/'/g, "'\\''")}'`).join(' ');
-  const env = extraEnv ? { ...process.env, ...extraEnv } : process.env;
-  return pty.spawn('zsh', ['-l', '-c', `${bin} ${quoted}`], {
-    name: 'xterm-256color',
-    cols,
-    rows,
-    cwd,
-    env
-  });
-}
-
-// Spawn Gemini CLI with full login shell environment
-function spawnGemini(args, cwd, { cols = 120, rows = 40, env: extraEnv } = {}) {
-  const bin = settings.geminiBinary || 'gemini';
-  const quoted = args.map(a => `'${a.replace(/'/g, "'\\''")}'`).join(' ');
-  const env = extraEnv ? { ...process.env, ...extraEnv } : process.env;
-  return pty.spawn('zsh', ['-l', '-c', `${bin} ${quoted}`], {
-    name: 'xterm-256color',
-    cols,
-    rows,
-    cwd,
-    env
-  });
+  engine.spawn(id, 'zsh', ['-l', '-c', `${bin} ${quoted}`], cwd, { cols, rows, env });
 }
 
 // Agent capabilities and argument mapping
 const AGENT_CONFIGS = {
   claude: {
-    spawn: spawnClaude,
     supportsWorktree: true,
     supportsSessionId: true,
     supportsSessionWatch: true,
@@ -465,7 +461,6 @@ const AGENT_CONFIGS = {
     resumeDefault: '-c'
   },
   gemini: {
-    spawn: spawnGemini,
     supportsWorktree: false,
     supportsSessionId: false, // Managed internally
     supportsSessionWatch: false,
@@ -478,7 +473,6 @@ const AGENT_CONFIGS = {
     resumeDefault: '-c'
   },
   opencode: {
-    spawn: spawnOpenCode,
     supportsWorktree: false,
     supportsSessionId: true,
     supportsSessionWatch: false,
@@ -497,10 +491,9 @@ function getAgentConfig(agentType) {
   return AGENT_CONFIGS[agentType] || AGENT_CONFIGS.claude;
 }
 
-// Dispatch to the correct spawn function based on agent type
-function spawnAgent(agentType, args, cwd, opts = {}) {
-  const config = getAgentConfig(agentType);
-  return config.spawn(args, cwd, opts);
+// Kept for backward compatibility with MCP context — delegates to spawnSession
+function spawnAgent(id, agentType, args, cwd, opts = {}) {
+  spawnSession(id, agentType, args, cwd, opts);
 }
 
 function getSpawnArgs(agentType, { sessionId, planMode, worktree }) {
@@ -684,9 +677,9 @@ function unwatchClaudeSessionDir(shellId) {
  * text first, then send \r in a separate write after a short delay to ensure
  * they land in different readable events.
  */
-function submitToShell(shell, text) {
-  shell.write(text);
-  setTimeout(() => shell.write('\r'), 1000);
+function submitToShell(id, text) {
+  engine.write(id, text);
+  setTimeout(() => engine.write(id, '\r'), 1000);
 }
 
 /**
@@ -716,9 +709,9 @@ function deliverPromptWhenReady(id, prompt) {
   const config = getAgentConfig(e.agentType);
   if (e.waitingForInput) {
     e.waitingForInput = false;
-    setTimeout(() => submitToShell(e.shell, prompt), 500);
+    setTimeout(() => submitToShell(id, prompt), 500);
   } else if (config.initialPromptDelay > 0) {
-    setTimeout(() => submitToShell(e.shell, prompt), config.initialPromptDelay);
+    setTimeout(() => submitToShell(id, prompt), config.initialPromptDelay);
   } else {
     e.initialPrompt = prompt;  // BEL handler will pick it up
   }
@@ -761,7 +754,9 @@ function wireShellOutput(id) {
   if (!entry) return;
   if (!entry.scrollback) entry.scrollback = [];
   if (!entry.scrollbackSize) entry.scrollbackSize = 0;
-  entry.shell.onData((data) => {
+
+  const dataHandler = (sid, data) => {
+    if (sid !== id) return;
     const e = shells.get(id);
     if (!e) return;
     e.lastActivity = Date.now();
@@ -816,7 +811,7 @@ function wireShellOutput(id) {
             const prompt = e.initialPrompt;
             e.initialPrompt = null;
             e.waitingForInput = false;
-            setTimeout(() => submitToShell(e.shell, prompt), 500);
+            setTimeout(() => submitToShell(id, prompt), 500);
           }
         }
         // If already waiting, the BEL just refreshes lastBelTime (keeps it stable)
@@ -838,7 +833,11 @@ function wireShellOutput(id) {
       }
     }
     e.clients.forEach((c) => c.send(data));
-  });
+  };
+
+  engine.on('data', dataHandler);
+  // Store reference for cleanup
+  entry._engineDataHandler = dataHandler;
 }
 
 // Gracefully kill a shell
@@ -846,57 +845,68 @@ function killShell(entry, id) {
   if (entry.killed) return;
   entry.killed = true;
 
-  const pid = entry.shell.pid;
+  // tmux-attach sessions manage their own PTY — just detach
+  if (entry.agentType === 'tmux-attach') {
+    if (entry._attachPty) {
+      try { entry._attachPty.kill(); } catch {}
+    }
+    return;
+  }
+
+  const pid = engine.getPid(id);
   const config = getAgentConfig(entry.agentType);
   log(`Killing shell ${id} (pid=${pid}, agent=${entry.agentType || 'claude'}, waitingForInput=${entry.waitingForInput})`);
 
+  // Clean up engine data listener
+  if (entry._engineDataHandler) {
+    engine.removeListener('data', entry._engineDataHandler);
+    entry._engineDataHandler = null;
+  }
+
   if (config.exitMethod === 'ctrl-c') {
     // Agent just needs Ctrl+C (OpenCode, Gemini)
-    try { entry.shell.write('\x03'); } catch {}
+    try { engine.write(id, '\x03'); } catch {}
   } else if (config.exitMethod === 'exit-cmd') {
     // Agent supports /exit command (Claude)
     if (entry.waitingForInput) {
       // Safe to send /exit directly
-      try { submitToShell(entry.shell, '/exit'); } catch {}
+      try { submitToShell(id, '/exit'); } catch {}
     } else {
       // Claude is busy — send Ctrl+C to interrupt, then /exit when it's ready
-      try { entry.shell.write('\x03'); } catch {}
+      try { engine.write(id, '\x03'); } catch {}
       // Watch for BEL (Claude back at prompt), then send /exit
-      const exitHandler = (data) => {
+      const exitHandler = (sid, data) => {
+        if (sid !== id) return;
         if (data.includes('\x07')) {
-          entry.shell.removeListener('data', exitHandler);
-          try { submitToShell(entry.shell, '/exit'); } catch {}
+          engine.removeListener('data', exitHandler);
+          try { submitToShell(id, '/exit'); } catch {}
         }
       };
-      entry.shell.onData(exitHandler);
+      engine.on('data', exitHandler);
     }
   } else {
     // Default fallback: just kill the process group
-    try { process.kill(-pid, 'SIGTERM'); } catch {}
+    try { engine.kill(id, 'SIGTERM'); } catch {}
   }
 
   // After 8 seconds, escalate to SIGTERM
   setTimeout(() => {
+    const currentPid = engine.getPid(id);
+    if (!currentPid) return; // Already dead
     try {
-      process.kill(pid, 0); // Check if still alive
+      process.kill(currentPid, 0); // Check if still alive
       log(`Shell ${id} still alive after /exit, sending SIGTERM`);
-      try {
-        process.kill(-pid, 'SIGTERM');
-      } catch {
-        try { entry.shell.kill('SIGTERM'); } catch {}
-      }
+      engine.kill(id, 'SIGTERM');
     } catch { return; } // Already dead
 
     // After 2 more seconds, escalate to SIGKILL
     setTimeout(() => {
+      const pid2 = engine.getPid(id);
+      if (!pid2) return;
       try {
-        process.kill(pid, 0);
+        process.kill(pid2, 0);
         log(`Shell ${id} still alive, sending SIGKILL`);
-        try {
-          process.kill(-pid, 'SIGKILL');
-        } catch {
-          try { entry.shell.kill('SIGKILL'); } catch {}
-        }
+        engine.kill(id, 'SIGKILL');
       } catch {}
     }, 2000);
   }, 8000);
@@ -945,6 +955,7 @@ function saveState() {
   }
   const state = {};
   for (const [id, entry] of shells) {
+    if (entry.agentType === 'tmux-attach') continue; // ephemeral — don't persist
     state[id] = { cwd: entry.cwd, claudeSessionId: entry.claudeSessionId, agentType: entry.agentType || 'claude', worktree: entry.worktree || null, name: entry.name || null, lastActivity: entry.lastActivity || null, createdAt: entry.createdAt || null, windowId: entry.windowId || null };
   }
   // Merge with any saved state that wasn't reconnected yet
@@ -1014,8 +1025,8 @@ async function shutdown(signal) {
 
   // Phase 2: Wait up to 8s for shells to exit naturally (1s for \r delay + time to save)
   const alive = new Set(entries.map(([id]) => id));
-  for (const [id, entry] of entries) {
-    entry.shell.onExit(() => alive.delete(id));
+  for (const [id] of entries) {
+    engine.onExit(id, () => alive.delete(id));
   }
 
   const deadline = Date.now() + 8000;
@@ -1033,6 +1044,7 @@ async function shutdown(signal) {
   {
     const state = {};
     for (const [sid, sentry] of shells) {
+      if (sentry.agentType === 'tmux-attach') continue;
       state[sid] = { cwd: sentry.cwd, claudeSessionId: sentry.claudeSessionId, agentType: sentry.agentType || 'claude', worktree: sentry.worktree || null, name: sentry.name || null, lastActivity: sentry.lastActivity || null };
     }
     const merged = { ...savedState, ...state };
@@ -1052,21 +1064,13 @@ async function shutdown(signal) {
   // Phase 3: SIGTERM remaining
   log(`${alive.size} shells still alive, sending SIGTERM...`);
   for (const id of alive) {
-    const entry = shells.get(id);
-    if (!entry) continue;
-    try { process.kill(-entry.shell.pid, 'SIGTERM'); } catch {
-      try { entry.shell.kill('SIGTERM'); } catch {}
-    }
+    try { engine.kill(id, 'SIGTERM'); } catch {}
   }
 
   // Phase 4: Wait 2s more, then force kill
   await new Promise(r => setTimeout(r, 2000));
   for (const id of alive) {
-    const entry = shells.get(id);
-    if (!entry) continue;
-    try { process.kill(-entry.shell.pid, 'SIGKILL'); } catch {
-      try { entry.shell.kill('SIGKILL'); } catch {}
-    }
+    try { engine.kill(id, 'SIGKILL'); } catch {}
   }
 
   log('Shutdown complete');
@@ -1132,6 +1136,42 @@ app.get('/api/settings', (req, res) => {
 });
 
 app.get('/api/settings/defaults', (req, res) => res.json(SETTINGS_DEFAULTS));
+
+app.get('/api/engines', (req, res) => {
+  let tmuxAvailable = false;
+  let tmuxVersion = null;
+  try {
+    const out = execSync("zsh -l -c 'tmux -V'", { encoding: 'utf8', timeout: 5000 }).trim();
+    const match = out.match(/(\d+\.\d+)/);
+    tmuxVersion = match ? match[1] : out;
+    tmuxAvailable = true;
+  } catch {}
+  res.json({
+    engines: [
+      { id: 'node-pty', name: 'node-pty (built-in)', available: true },
+      { id: 'tmux', name: 'tmux', available: tmuxAvailable, version: tmuxVersion },
+    ],
+    current: settings.engine || 'node-pty',
+  });
+});
+
+app.get('/api/tmux-sessions', (req, res) => {
+  try {
+    const out = execSync("zsh -l -c 'tmux list-sessions -F \"#{session_name}\t#{session_windows}\t#{session_width}\t#{session_height}\t#{session_created}\"'", {
+      encoding: 'utf8', timeout: 5000, stdio: 'pipe',
+    }).trim();
+    if (!out) return res.json({ sessions: [] });
+    const sessions = out.split('\n').map(line => {
+      const [name, windows, width, height, created] = line.split('\t');
+      // Check if any deepsteve shell is already attached to this session
+      const attached = [...shells.values()].some(e => e.tmuxSession === name);
+      return { name, windows: parseInt(windows) || 1, width: parseInt(width), height: parseInt(height), created: parseInt(created) || null, attached };
+    });
+    res.json({ sessions });
+  } catch {
+    res.json({ sessions: [] });
+  }
+});
 
 app.post('/api/settings', (req, res) => {
   const { shellProfile, maxIssueTitleLength } = req.body;
@@ -1200,6 +1240,28 @@ app.post('/api/settings', (req, res) => {
         tabs: c.tabs.filter(t => t && typeof t === 'object' && validateConfigTab(t)).map(sanitizeConfigTab),
       }));
       log(`Settings updated: windowConfigs (${settings.windowConfigs.length} configs)`);
+    }
+  }
+  if (req.body.engine !== undefined) {
+    const requested = String(req.body.engine);
+    if (requested === 'node-pty' || requested === 'tmux') {
+      if (requested !== settings.engine) {
+        // Check if there are active sessions
+        if (shells.size > 0 && !req.body.engineSwitchConfirm) {
+          return res.json({ ...settings, engineSwitchRequired: true, activeSessions: shells.size });
+        }
+        // Kill all active sessions before switching
+        if (shells.size > 0) {
+          for (const [sid, sentry] of shells) {
+            killShell(sentry, sid);
+            shells.delete(sid);
+          }
+          saveState();
+        }
+        settings.engine = requested;
+        initEngine();
+        log(`Settings updated: engine=${settings.engine}`);
+      }
     }
   }
   saveSettings();
@@ -1335,11 +1397,11 @@ app.post('/api/window-configs/:id/apply', (req, res) => {
     const spawnArgs = getSpawnArgs(agentType, { sessionId: claudeSessionId });
     const name = tab.name || path.basename(cwd);
 
-    const shell = spawnAgent(agentType, spawnArgs, cwd, { cols: 120, rows: 40, env: { DEEPSTEVE_SESSION_ID: id } });
-    shells.set(id, { shell, clients: new Set(), cwd, claudeSessionId, agentType, worktree: null, windowId: windowId || null, name, initialPrompt: null, waitingForInput: false, lastActivity: Date.now(), createdAt: Date.now() });
+    spawnSession(id, agentType, spawnArgs, cwd, { cols: 120, rows: 40, env: { DEEPSTEVE_SESSION_ID: id } });
+    shells.set(id, { clients: new Set(), cwd, claudeSessionId, agentType, worktree: null, windowId: windowId || null, name, initialPrompt: null, waitingForInput: false, lastActivity: Date.now(), createdAt: Date.now() });
     wireShellOutput(id);
     if (agentConfig.supportsSessionWatch) watchClaudeSessionDir(id);
-    shell.onExit(() => {
+    engine.onExit(id, () => {
       if (agentConfig.supportsSessionWatch) unwatchClaudeSessionDir(id);
       if (!shuttingDown) { shells.delete(id); saveState(); }
     });
@@ -1711,7 +1773,7 @@ app.delete('/api/display-tab/:id', (req, res) => {
 });
 
 app.get('/api/shells', (req, res) => {
-  const active = [...shells.entries()].map(([id, entry]) => ({ id, pid: entry.shell.pid, cwd: entry.cwd, name: entry.name || null, agentType: entry.agentType || 'claude', status: 'active', lastActivity: entry.lastActivity || null, connectedClients: entry.clients.size }));
+  const active = [...shells.entries()].map(([id, entry]) => ({ id, pid: engine.getPid(id), cwd: entry.cwd, name: entry.name || null, agentType: entry.agentType || 'claude', status: 'active', lastActivity: entry.lastActivity || null, connectedClients: entry.clients.size }));
   const saved = Object.entries(savedState).map(([id, entry]) => ({ id, cwd: entry.cwd, name: entry.name || null, agentType: entry.agentType || 'claude', status: entry.closed ? 'closed' : 'saved', lastActivity: entry.lastActivity || null, connectedClients: 0 }));
   res.json({ shells: [...active, ...saved] });
 });
@@ -1719,7 +1781,7 @@ app.get('/api/shells', (req, res) => {
 app.post('/api/shells/killall', (req, res) => {
   const killed = [];
   for (const [id, entry] of shells) {
-    killed.push({ id, pid: entry.shell.pid });
+    killed.push({ id, pid: engine.getPid(id) });
     killShell(entry, id);
     shells.delete(id);
   }
@@ -1971,16 +2033,16 @@ app.post('/api/start-issue', (req, res) => {
   const prompt = body ? buildPrompt(body, labels, url) : null;
 
   log(`[API] start-issue #${number}: id=${id}, agent=${agentType}, worktree=${worktree || 'none'}, cwd=${worktreeCwd}`);
-  const shell = spawnAgent(agentType, spawnArgs, worktreeCwd, { cols: 120, rows: 40, env: { DEEPSTEVE_SESSION_ID: id } });
-  shells.set(id, { shell, clients: new Set(), cwd: worktreeCwd, claudeSessionId: claudeSessionId, agentType, worktree: worktree || null, windowId: windowId || null, name, initialPrompt: prompt, waitingForInput: false, lastActivity: Date.now(), createdAt: Date.now() });
+  spawnSession(id, agentType, spawnArgs, worktreeCwd, { cols: 120, rows: 40, env: { DEEPSTEVE_SESSION_ID: id } });
+  shells.set(id, { clients: new Set(), cwd: worktreeCwd, claudeSessionId: claudeSessionId, agentType, worktree: worktree || null, windowId: windowId || null, name, initialPrompt: prompt, waitingForInput: false, lastActivity: Date.now(), createdAt: Date.now() });
   wireShellOutput(id);
   // For non-BEL agents with a synchronous prompt, deliver after delay
   if (prompt && agentConfig.initialPromptDelay > 0) {
     shells.get(id).initialPrompt = null; // Clear so BEL handler doesn't also fire
-    setTimeout(() => submitToShell(shell, prompt), agentConfig.initialPromptDelay);
+    setTimeout(() => submitToShell(id, prompt), agentConfig.initialPromptDelay);
   }
   if (agentConfig.supportsSessionWatch) watchClaudeSessionDir(id);
-  shell.onExit(() => {
+  engine.onExit(id, () => {
     if (agentConfig.supportsSessionWatch) unwatchClaudeSessionDir(id);
     if (!shuttingDown) { shells.delete(id); saveState(); }
   });
@@ -2085,6 +2147,50 @@ const server = app.listen(PORT, BIND, () => {
 });
 const shells = new Map();
 const displayTabs = new Map(); // id → HTML string (disk-backed in ~/.deepsteve/display-tabs/)
+
+// --- tmux session reattach on startup ---
+// When engine is tmux, check for surviving tmux sessions and reattach them.
+if (engine instanceof TmuxEngine) {
+  const tmuxSessions = engine.listSessions();
+  if (tmuxSessions.length > 0) {
+    log(`tmux: found ${tmuxSessions.length} surviving session(s): ${tmuxSessions.join(', ')}`);
+    for (const id of tmuxSessions) {
+      const meta = savedState[id];
+      if (!meta) {
+        log(`tmux: session ${id} has no metadata in state.json, killing orphan`);
+        engine.destroy(id);
+        continue;
+      }
+      if (engine.reattach(id, 120, 40)) {
+        const agentConfig = getAgentConfig(meta.agentType || 'claude');
+        shells.set(id, {
+          clients: new Set(),
+          cwd: meta.cwd,
+          claudeSessionId: meta.claudeSessionId,
+          agentType: meta.agentType || 'claude',
+          worktree: meta.worktree || null,
+          name: meta.name || null,
+          restored: true,
+          waitingForInput: false,
+          lastActivity: meta.lastActivity || Date.now(),
+          createdAt: meta.createdAt || Date.now(),
+          windowId: meta.windowId || null,
+        });
+        wireShellOutput(id);
+        if (agentConfig.supportsSessionWatch) watchClaudeSessionDir(id);
+        engine.onExit(id, () => {
+          if (agentConfig.supportsSessionWatch) unwatchClaudeSessionDir(id);
+          if (!shuttingDown) { shells.delete(id); saveState(); }
+        });
+        delete savedState[id];
+        log(`tmux: reattached session ${id} (${meta.name || meta.cwd})`);
+      } else {
+        log(`tmux: failed to reattach session ${id}`);
+      }
+    }
+    saveState();
+  }
+}
 
 function setDisplayTab(id, html) {
   displayTabs.set(id, html);
@@ -2195,6 +2301,121 @@ function handleWsConnection(ws, req) {
     return;
   }
 
+  // Attach to an existing tmux session (raw terminal, no agent features)
+  if (action === 'tmux-attach') {
+    const tmuxSession = url.searchParams.get('session');
+    const windowId = url.searchParams.get('windowId') || null;
+    const initialCols = parseInt(url.searchParams.get('cols')) || 120;
+    const initialRows = parseInt(url.searchParams.get('rows')) || 40;
+    const tabName = url.searchParams.get('name') || tmuxSession;
+
+    if (!tmuxSession) {
+      ws.send(JSON.stringify({ type: 'error', message: 'Missing session parameter' }));
+      ws.close();
+      return;
+    }
+
+    // Check tmux session exists
+    try {
+      execSync(`zsh -l -c 'tmux has-session -t "${tmuxSession.replace(/"/g, '\\"')}"'`, { timeout: 5000, stdio: 'pipe' });
+    } catch {
+      ws.send(JSON.stringify({ type: 'error', message: `tmux session "${tmuxSession}" not found` }));
+      ws.close();
+      return;
+    }
+
+    const pty = require('node-pty');
+    const id = randomUUID().slice(0, 8);
+    const attachPty = pty.spawn('tmux', ['attach-session', '-t', tmuxSession], {
+      name: 'xterm-256color',
+      cols: initialCols,
+      rows: initialRows,
+    });
+
+    const entry = {
+      clients: new Set(),
+      cwd: null,
+      claudeSessionId: null,
+      agentType: 'tmux-attach',
+      tmuxSession,
+      worktree: null,
+      name: tabName,
+      waitingForInput: false,
+      lastActivity: Date.now(),
+      createdAt: Date.now(),
+      windowId,
+      scrollback: [],
+      scrollbackSize: 0,
+      _attachPty: attachPty,
+    };
+    shells.set(id, entry);
+
+    attachPty.onData((data) => {
+      const e = shells.get(id);
+      if (!e) return;
+      e.lastActivity = Date.now();
+      e.scrollback.push(data);
+      e.scrollbackSize += data.length;
+      while (e.scrollbackSize > SCROLLBACK_SIZE && e.scrollback.length > 1) {
+        e.scrollbackSize -= e.scrollback.shift().length;
+      }
+      e.clients.forEach((c) => c.send(data));
+    });
+
+    attachPty.onExit(() => {
+      if (!shuttingDown) { shells.delete(id); }
+    });
+
+    log(`[WS] tmux-attach: id=${id}, session=${tmuxSession}`);
+
+    entry.clients.add(ws);
+    ws.send(JSON.stringify({ type: 'session', id, restored: false, cwd: null, name: tabName, agentType: 'tmux-attach', scrollback: false, existingClients: 0 }));
+
+    ws.on('message', (msg) => {
+      const str = msg.toString();
+      try {
+        const parsed = JSON.parse(str);
+        if (parsed.type === 'resize') {
+          attachPty.resize(parsed.cols, parsed.rows);
+          // Also resize the tmux window
+          try { execSync(`zsh -l -c 'tmux resize-window -t "${tmuxSession.replace(/"/g, '\\"')}" -x ${parsed.cols} -y ${parsed.rows}'`, { timeout: 5000, stdio: 'pipe' }); } catch {}
+          return;
+        }
+        if (parsed.type === 'redraw') { attachPty.write('\x0c'); return; }
+        if (parsed.type === 'rename') { entry.name = parsed.name || null; return; }
+        if (parsed.type === 'close-session') {
+          // Detach only — don't kill the tmux session
+          entry.clients.delete(ws);
+          ws.close();
+          if (entry.clients.size === 0) {
+            log(`[WS] tmux-attach: detaching from ${tmuxSession} (last client)`);
+            try { attachPty.kill(); } catch {}
+            shells.delete(id);
+          }
+          return;
+        }
+      } catch {}
+      entry.lastActivity = Date.now();
+      attachPty.write(str);
+    });
+
+    ws.on('close', () => {
+      if (!shells.has(id)) return;
+      entry.clients.delete(ws);
+      if (entry.clients.size === 0) {
+        // Detach after grace period
+        entry.killTimer = setTimeout(() => {
+          if (entry.clients.size === 0) {
+            log(`[WS] tmux-attach: detaching from ${tmuxSession} (grace period expired)`);
+            try { attachPty.kill(); } catch {}
+            shells.delete(id);
+          }
+        }, 30000);
+      }
+    });
+    return;
+  }
+
   let id = url.searchParams.get('id');
   let cwd = url.searchParams.get('cwd') || process.env.HOME;
   if (cwd.startsWith('~')) cwd = path.join(os.homedir(), cwd.slice(1));
@@ -2230,13 +2451,13 @@ function handleWsConnection(ws, req) {
         worktree: savedWorktree 
       });
 
-      const shell = spawnAgent(savedAgentType, resumeArgs, cwd, { ...ptySize, env: { DEEPSTEVE_SESSION_ID: id } });
+      spawnSession(id, savedAgentType, resumeArgs, cwd, { ...ptySize, env: { DEEPSTEVE_SESSION_ID: id } });
       const startTime = Date.now();
       const restoredName = name || restored.name || null;
-      shells.set(id, { shell, clients: new Set(), cwd, claudeSessionId, agentType: savedAgentType, worktree: savedWorktree, name: restoredName, restored: true, waitingForInput: false, lastActivity: Date.now(), createdAt: restored.createdAt || Date.now(), windowId: restored.windowId || null });
+      shells.set(id, { clients: new Set(), cwd, claudeSessionId, agentType: savedAgentType, worktree: savedWorktree, name: restoredName, restored: true, waitingForInput: false, lastActivity: Date.now(), createdAt: restored.createdAt || Date.now(), windowId: restored.windowId || null });
       wireShellOutput(id);
       if (agentConfig.supportsSessionWatch) watchClaudeSessionDir(id);
-      shell.onExit(() => {
+      engine.onExit(id, () => {
         if (agentConfig.supportsSessionWatch) unwatchClaudeSessionDir(id);
         if (shuttingDown) return;  // Don't overwrite state file during shutdown
         const elapsed = Date.now() - startTime;
@@ -2247,16 +2468,16 @@ function handleWsConnection(ws, req) {
           const entry = shells.get(id);
           const fallbackArgs = ['-c', '--fork-session', '--session-id', newClaudeSessionId];
           if (entry && entry.worktree) fallbackArgs.push('--worktree', entry.worktree);
-          const fallbackShell = spawnClaude(fallbackArgs, cwd, { cols: initialCols, rows: initialRows, env: { DEEPSTEVE_SESSION_ID: id } });
+          engine.destroy(id);
+          spawnSession(id, 'claude', fallbackArgs, cwd, { cols: initialCols, rows: initialRows, env: { DEEPSTEVE_SESSION_ID: id } });
           if (entry) {
-            entry.shell = fallbackShell;
             entry.claudeSessionId = newClaudeSessionId;
             entry.killed = false;
             entry.scrollback = [];
             entry.scrollbackSize = 0;
             wireShellOutput(id);
             watchClaudeSessionDir(id);
-            fallbackShell.onExit(() => { if (!shuttingDown) { unwatchClaudeSessionDir(id); shells.delete(id); saveState(); } });
+            engine.onExit(id, () => { if (!shuttingDown) { unwatchClaudeSessionDir(id); shells.delete(id); saveState(); } });
             saveState();
           }
         } else {
@@ -2292,11 +2513,11 @@ function handleWsConnection(ws, req) {
     });
 
     log(`[WS] Creating NEW shell: oldId=${oldId}, newId=${id}, agent=${agentType}, session=${sessionId}, worktree=${worktree || 'none'}, cwd=${worktreeCwd}`);
-    const shell = spawnAgent(agentType, spawnArgs, worktreeCwd, { cols: initialCols, rows: initialRows, env: { DEEPSTEVE_SESSION_ID: id } });
-    shells.set(id, { shell, clients: new Set(), cwd: worktreeCwd, claudeSessionId: sessionId, agentType, worktree: worktree || null, name: name || null, waitingForInput: false, lastActivity: Date.now(), createdAt: Date.now() });
+    spawnSession(id, agentType, spawnArgs, worktreeCwd, { cols: initialCols, rows: initialRows, env: { DEEPSTEVE_SESSION_ID: id } });
+    shells.set(id, { clients: new Set(), cwd: worktreeCwd, claudeSessionId: sessionId, agentType, worktree: worktree || null, name: name || null, waitingForInput: false, lastActivity: Date.now(), createdAt: Date.now() });
     wireShellOutput(id);
     if (agentConfig.supportsSessionWatch) watchClaudeSessionDir(id);
-    shell.onExit(() => { if (!shuttingDown) { if (agentConfig.supportsSessionWatch) unwatchClaudeSessionDir(id); shells.delete(id); saveState(); } });
+    engine.onExit(id, () => { if (!shuttingDown) { if (agentConfig.supportsSessionWatch) unwatchClaudeSessionDir(id); shells.delete(id); saveState(); } });
     saveState();
   }
 
@@ -2324,15 +2545,15 @@ function handleWsConnection(ws, req) {
     const str = msg.toString();
     try {
       const parsed = JSON.parse(str);
-      if (parsed.type === 'resize') { entry.shell.resize(parsed.cols, parsed.rows); return; }
-      if (parsed.type === 'redraw') { entry.shell.write('\x0c'); return; } // Ctrl+L
+      if (parsed.type === 'resize') { engine.resize(id, parsed.cols, parsed.rows); return; }
+      if (parsed.type === 'redraw') { engine.write(id, '\x0c'); return; } // Ctrl+L
       if (parsed.type === 'initialPrompt') {
         const config = getAgentConfig(entry.agentType);
         if (config.initialPromptDelay > 0) {
           // Agent doesn't emit BEL, so submit the prompt directly after a delay
           // to give the TUI time to initialize
           const prompt = parsed.text;
-          setTimeout(() => submitToShell(entry.shell, prompt), config.initialPromptDelay);
+          setTimeout(() => submitToShell(id, prompt), config.initialPromptDelay);
         } else {
           entry.initialPrompt = parsed.text;
         }
@@ -2367,7 +2588,7 @@ function handleWsConnection(ws, req) {
       const stateMsg = JSON.stringify({ type: 'state', waiting: false });
       entry.clients.forEach((c) => c.send(stateMsg));
     }
-    entry.shell.write(str);
+    engine.write(id, str);
   });
 
   ws.on('close', () => {
@@ -2418,7 +2639,7 @@ function broadcastToWindow(windowId, msg) {
 }
 
 // Initialize MCP server (async, ~100ms for dynamic import)
-initMCP({ app, shells, wss, broadcast, broadcastToWindow, log, MODS_DIR, closeSession, spawnAgent, getSpawnArgs, getAgentConfig, wireShellOutput, watchClaudeSessionDir, unwatchClaudeSessionDir, saveState, validateWorktree, ensureWorktree, submitToShell, fetchIssueFromGitHub, deliverPromptWhenReady, reloadClients, pendingOpens, settings, isShuttingDown: () => shuttingDown, displayTabs, setDisplayTab, deleteDisplayTab }).catch(e => log('MCP init failed:', e.message));
+initMCP({ app, shells, wss, broadcast, broadcastToWindow, log, MODS_DIR, closeSession, spawnSession, engine, getSpawnArgs, getAgentConfig, wireShellOutput, watchClaudeSessionDir, unwatchClaudeSessionDir, saveState, validateWorktree, ensureWorktree, submitToShell, fetchIssueFromGitHub, deliverPromptWhenReady, reloadClients, pendingOpens, settings, isShuttingDown: () => shuttingDown, displayTabs, setDisplayTab, deleteDisplayTab }).catch(e => log('MCP init failed:', e.message));
 
 // Watch themes directory for changes and broadcast to clients
 let themeWatchDebounce = null;


### PR DESCRIPTION
## Summary

- Extracts all terminal session management from inline `node-pty` calls behind a pluggable `Engine` interface (`engines/engine.js`), with `node-pty` as the default (`engines/node-pty.js`) and `tmux` as an opt-in backend (`engines/tmux.js`)
- tmux sessions survive daemon restarts — on startup, surviving `ds-*` sessions are reattached automatically using metadata from `state.json`
- Adds "Attach tmux session" to the new-tab dropdown menu, letting users connect to **any** existing tmux session on the machine (not just deepsteve-managed ones). Attached sessions detach on tab close, leaving the tmux session running
- Adds Terminal Engine selector to Settings > General with confirmation dialog when switching engines with active sessions
- Adds `GET /api/engines` and `GET /api/tmux-sessions` endpoints

Closes #33

## Test plan

- [ ] **node-pty regression**: Start daemon, create sessions, verify PTY I/O, resize, kill, restore after restart all work identically
- [ ] **tmux engine**: Switch engine to tmux in settings, create session, verify terminal works, resize, kill. Restart daemon and verify tmux sessions survive and reattach
- [ ] **Engine switch**: Switch from node-pty to tmux with active sessions — confirm dialog appears, sessions are killed, new sessions use tmux
- [ ] **tmux unavailable**: Verify option is disabled in settings UI when tmux not installed, verify server falls back gracefully
- [ ] **Attach tmux session**: Create a tmux session externally, attach via new-tab menu, verify I/O works, verify closing tab detaches (doesn't kill the tmux session)
- [ ] **MCP tools**: Verify `open_terminal`, `start_issue`, `close_session` work with both engines

🤖 Generated with [Claude Code](https://claude.com/claude-code)