### PR TITLE
Migrate GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/check-installer.yml
+++ b/.github/workflows/check-installer.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   check:
     runs-on: macos-latest

--- a/.github/workflows/install-integration-tests.yml
+++ b/.github/workflows/install-integration-tests.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 8 * * *'
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,6 +9,9 @@ on:
     # Daily at 8am UTC
     - cron: '0 8 * * *'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env var to all three workflow files to opt in to Node 24 before the forced migration on June 2, 2026

## Test plan

- [ ] Verify all three CI workflows pass on this PR with Node 24 enabled

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)