### PR TITLE
Add watchdog for failed meta-refresh reload (#438)

### DIFF
--- a/public/js/live-reload.js
+++ b/public/js/live-reload.js
@@ -108,6 +108,14 @@ export function initLiveReload({ onMessage, onShowRestartConfirm, onShowReloadOv
           meta.httpEquiv = 'refresh';
           meta.content = '0;url=' + location.pathname + '?_=' + Date.now();
           document.head.appendChild(meta);
+          // Watchdog: if meta-refresh silently fails to navigate, clear the
+          // reload flag so per-tab WS reconnects resume instead of wedging.
+          setTimeout(() => {
+            console.warn('[live-reload] meta-refresh did not navigate, falling back');
+            window.__deepsteveReloadPending = false;
+            reloading = false;
+            location.replace(location.pathname + '?_=' + Date.now());
+          }, 3000);
         }
       } catch {}
     }, 500);


### PR DESCRIPTION
## Summary
- After confirming a daemon restart, every per-tab session WS skips reconnect because `__deepsteveReloadPending` is true. If the meta-refresh injected by `pollAndReload` silently fails to navigate, the flag never clears and tabs are permanently wedged until the user hard-refreshes each browser window.
- This adds a 3s watchdog after the meta tag is appended: clear `__deepsteveReloadPending`, reset the local `reloading` guard, and call `location.replace()` as a fallback navigation. Worst case becomes a 3s reconnect delay instead of a permanent wedge.

Fixes #438

## Test plan
- [ ] From the main repo, run `./restart.sh --refresh` — confirm the happy path still reloads every open window cleanly.
- [ ] Simulate failure: temporarily remove `document.head.appendChild(meta)` and restart with `--refresh`. Expect `[live-reload] meta-refresh did not navigate, falling back` in the console after 3s, then `location.replace()` completes the navigation.
- [ ] Wedge regression check: before the fix, manually `window.__deepsteveReloadPending = true` and close a session WS — no reconnect. After the fix, the simulated failure clears the flag within 3s and reconnect resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)