### PR TITLE
Scheduled tasks: make the worktree-isolation gate pure-fs instead of shelling out to zsh

### DIFF
--- a/mods/scheduled-tasks/tools.js
+++ b/mods/scheduled-tasks/tools.js
@@ -122,13 +122,18 @@ function gitRoot(dir) {
   return findGitRoot(dir) || dir;
 }
 
-// True when dir is inside a non-bare git work tree. gitRoot() can't answer this:
-// it returns its input on failure, indistinguishable from "dir IS the root".
+// True when dir is inside a git work tree — the gate for per-run worktree isolation.
+// gitRoot() can't answer this: its `|| dir` fallback makes "not a repo" and "dir IS
+// the root" the same answer. findGitRoot() can, by returning null.
+//
+// Pure-fs for the same reason gitRoot() is (#553), plus one this function taught us:
+// as `zsh -l -c 'git rev-parse --is-inside-work-tree'` it made worktree isolation
+// silently conditional on zsh being installed. Where it isn't, every fire fell back
+// to the shared checkout with nothing logged, and the #614 tombstone test — which
+// drives the whole runTask path — went red on the bare CI runner while the docker
+// suites (which apt-get zsh) stayed green.
 function isGitRepo(dir) {
-  try {
-    return execSync("zsh -l -c 'git rev-parse --is-inside-work-tree'",
-      { cwd: dir, encoding: 'utf8', timeout: 5000 }).trim() === 'true';
-  } catch { return false; }
+  return findGitRoot(dir) !== null;
 }
 
 // launchd-started daemons have a minimal PATH; login zsh matches gitRoot/ensureWorktree.

--- a/test/unit/scheduled-worktree.test.js
+++ b/test/unit/scheduled-worktree.test.js
@@ -115,10 +115,10 @@ test('bad args: no throw, nothing reported removed', () => {
   assert.deepStrictEqual(cleanupWorktree('/tmp', null, exec), { removed: false, branchDeleted: false });
 });
 
-test('isGitRepo distinguishes repos from plain dirs', (t) => {
-  // isGitRepo uses the production zsh -l -c path — skip where zsh is absent (CI).
-  try { execSync('command -v zsh', { encoding: 'utf8' }); }
-  catch { return t.skip('zsh not available'); }
+test('isGitRepo distinguishes repos from plain dirs', () => {
+  // No zsh skip here any more: isGitRepo is a pure-fs findGitRoot() check, so this
+  // runs on the bare CI runner too. While it shelled out to zsh this test was
+  // skipped there, which is how the gate reached #614's tombstone test unguarded.
   const repo = makeRepo();
   assert.strictEqual(isGitRepo(repo), true);
   const plain = fs.mkdtempSync(path.join(os.tmpdir(), 'ds-sched-plain-'));


### PR DESCRIPTION
Fixes the red `unit` job on `main` (red since 7ac5afa; the scheduled run and the #613 push run both failed).

## The failure

```
not ok 281 - an unreclaimed worktree keeps the tombstone alive for sweepLeakedWorktrees
  error: 'precondition: the run holds an unreclaimed worktree'
  expected: true / actual: ~
```

The workflow is named **Integration Tests**, but the failing job inside it is `unit` — the docker `test` job was passing throughout, which is why this looked green from the outside. It also passes locally on macOS.

## Root cause

`isGitRepo()` gated per-run worktree isolation (#565) on `zsh -l -c 'git rev-parse --is-inside-work-tree'`. The `unit` job runs bare on `ubuntu-latest` with only `npm install --ignore-scripts` — **no zsh**; only the docker suites `apt-get install zsh`. With no zsh the call throws, the gate returns false, no worktree is assigned, and `run.worktree` is `undefined` — hence `actual: ~`.

Confirmed by reproducing rather than inferring: rerunning the suite with a PATH containing git/node but no zsh gives the identical failure and assertion signature.

#565 already hit this and worked around it with `t.skip('zsh not available')` on its own `isGitRepo` test. #614 then added a test driving the whole `runTask` path, which reaches the same gate with no skip available.

## The fix

`findGitRoot(dir) !== null` — the pure-fs walk the file already imports, and the same treatment #553 gave `gitRoot()` directly above it.

This also fixes a latent product bug, not just the test: worktree isolation was silently conditional on zsh being installed, and where it wasn't, every scheduled fire fell back to the shared checkout with nothing logged. It removes a blocking login-shell subprocess (5s timeout) from the fire path too, which is #553's stated rationale.

The obsolete zsh skip is dropped so that assertion actually runs in CI — that skip is how the gate reached #614's test unguarded.

## Verification

| | result |
|---|---|
| Unit suite, no zsh on PATH (CI repro) | **457/457**, 0 skipped |
| Unit suite, normal | **457/457**, 0 skipped |
| `npm test` integration suite | **70/70** across 10 files, exit 0 |

The `isGitRepo` test now runs in the CI-shaped environment instead of being skipped there.

## Caveats

The pure-fs check differs from `git rev-parse` in edge cases that don't arise at this call site: it reports true for a path inside `.git/` itself (`task.project` is always a canonicalized repo root), and it doesn't require the `git` binary to exist. Bare repos still correctly return false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)